### PR TITLE
feature/mx-1070 Fix public api module

### DIFF
--- a/mex/common/backend_api/connector.py
+++ b/mex/common/backend_api/connector.py
@@ -1,6 +1,6 @@
 import json
 from itertools import groupby
-from typing import Any, Literal, TypeVar, cast
+from typing import Any, Literal, cast
 from urllib.parse import urljoin
 
 import backoff
@@ -9,12 +9,10 @@ from requests.exceptions import HTTPError, RequestException
 
 from mex.common.backend_api.models import BulkInsertResponse
 from mex.common.connector import BaseConnector
-from mex.common.models import ExtractedData, MergedItem, MExModel
+from mex.common.models import MExModel
 from mex.common.settings import BaseSettings
 from mex.common.transform import MExEncoder
 from mex.common.types import Identifier
-
-ModelT = TypeVar("ModelT", bound=MExModel)
 
 
 class BackendApiConnector(BaseConnector):
@@ -101,7 +99,7 @@ class BackendApiConnector(BaseConnector):
         """Close the connector's underlying requests session."""
         self.session.close()
 
-    def post_models(self, models: list[ExtractedData | MergedItem]) -> list[Identifier]:
+    def post_models(self, models: list[MExModel]) -> list[Identifier]:
         """Post models to Backend API in a bulk insertion request.
 
         Args:

--- a/mex/common/backend_api/connector.py
+++ b/mex/common/backend_api/connector.py
@@ -9,7 +9,7 @@ from requests.exceptions import HTTPError, RequestException
 
 from mex.common.backend_api.models import BulkInsertResponse
 from mex.common.connector import BaseConnector
-from mex.common.models.base import MExModel
+from mex.common.models import ExtractedData, MergedItem, MExModel
 from mex.common.settings import BaseSettings
 from mex.common.transform import MExEncoder
 from mex.common.types import Identifier
@@ -101,11 +101,11 @@ class BackendApiConnector(BaseConnector):
         """Close the connector's underlying requests session."""
         self.session.close()
 
-    def post_models(self, models: list[MExModel]) -> list[Identifier]:
+    def post_models(self, models: list[ExtractedData | MergedItem]) -> list[Identifier]:
         """Post models to Backend API in a bulk insertion request.
 
         Args:
-            models: MEx models to post
+            models: Extracted or merged models to post
 
         Raises:
             HTTPError: If insert was not accepted, crashes or times out
@@ -115,7 +115,7 @@ class BackendApiConnector(BaseConnector):
         """
         response = self.request(
             "POST",
-            "entity",
+            "ingest",
             {
                 entity_type: list(entities)
                 for entity_type, entities in groupby(

--- a/mex/common/backend_api/models.py
+++ b/mex/common/backend_api/models.py
@@ -1,4 +1,4 @@
-from mex.common.models.base import BaseModel
+from mex.common.models import BaseModel
 from mex.common.types import Identifier
 
 

--- a/mex/common/extract.py
+++ b/mex/common/extract.py
@@ -11,7 +11,7 @@ from mex.common.logging import echo
 if TYPE_CHECKING:  # pragma: no cover
     from pandas._typing import Dtype, ReadCsvBuffer
 
-    from mex.common.models.base import BaseModel
+    from mex.common.models import BaseModel
 
 ModelT = TypeVar("ModelT", bound="BaseModel")
 

--- a/mex/common/ldap/extract.py
+++ b/mex/common/ldap/extract.py
@@ -3,7 +3,7 @@ from typing import Hashable, Iterable, cast
 
 from mex.common.identity.connector import IdentityConnector
 from mex.common.ldap.models.person import LDAPPerson, LDAPPersonWithQuery
-from mex.common.models.primary_source import ExtractedPrimarySource
+from mex.common.models import ExtractedPrimarySource
 from mex.common.types import Identifier
 
 

--- a/mex/common/ldap/models/actor.py
+++ b/mex/common/ldap/models/actor.py
@@ -1,6 +1,6 @@
 from pydantic import UUID4, NoneStr
 
-from mex.common.models.base import BaseModel
+from mex.common.models import BaseModel
 from mex.common.types import Email
 
 

--- a/mex/common/ldap/models/person.py
+++ b/mex/common/ldap/models/person.py
@@ -1,7 +1,7 @@
 from pydantic import Field, NoneStr
 
 from mex.common.ldap.models.actor import LDAPActor
-from mex.common.models.base import BaseModel
+from mex.common.models import BaseModel
 
 
 class LDAPPerson(LDAPActor):

--- a/mex/common/ldap/transform.py
+++ b/mex/common/ldap/transform.py
@@ -6,9 +6,11 @@ from typing import Generator, Iterable
 from mex.common.exceptions import MExError
 from mex.common.ldap.models.person import LDAPPerson, LDAPPersonWithQuery
 from mex.common.logging import watch
-from mex.common.models.organizational_unit import ExtractedOrganizationalUnit
-from mex.common.models.person import ExtractedPerson
-from mex.common.models.primary_source import ExtractedPrimarySource
+from mex.common.models import (
+    ExtractedOrganizationalUnit,
+    ExtractedPerson,
+    ExtractedPrimarySource,
+)
 
 
 @watch

--- a/mex/common/models/base.py
+++ b/mex/common/models/base.py
@@ -168,6 +168,9 @@ class MExModel(BaseModel):
     class Config:
         extra = Extra.forbid
 
+    if TYPE_CHECKING:
+        stableTargetId: Any
+
     identifier: Identifier = Field(
         ...,
         description="The identifier of this instance.",

--- a/mex/common/models/extracted_data.py
+++ b/mex/common/models/extracted_data.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from pydantic import Field, root_validator
 
@@ -16,8 +16,6 @@ class BaseExtractedData(MExModel):
     identifierInPrimarySource: str = Field(
         ..., examples=["123456", "item-501", "D7/x4/zz.final3"], min_length=1
     )
-    if TYPE_CHECKING:
-        stableTargetId: Any  # to be defined in subclasses
 
     @classmethod
     def get_entity_type(cls) -> str:
@@ -36,9 +34,6 @@ class BaseExtractedData(MExModel):
 
 class ExtractedData(BaseExtractedData):
     """Base model class for extracted data instances that ensures identities."""
-
-    if TYPE_CHECKING:
-        stableTargetId: Identifier
 
     @root_validator(pre=True)
     def set_identifiers(cls, values: dict[str, Any]) -> dict[str, Any]:

--- a/mex/common/models/extracted_data.py
+++ b/mex/common/models/extracted_data.py
@@ -37,6 +37,9 @@ class BaseExtractedData(MExModel):
 class ExtractedData(BaseExtractedData):
     """Base model class for extracted data instances that ensures identities."""
 
+    if TYPE_CHECKING:
+        stableTargetId: Identifier
+
     @root_validator(pre=True)
     def set_identifiers(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Ensure identifier and provenance attributes are set for this instance.

--- a/mex/common/models/merged_item.py
+++ b/mex/common/models/merged_item.py
@@ -1,14 +1,8 @@
-from typing import TYPE_CHECKING
-
 from mex.common.models.base import MExModel
-from mex.common.types import Identifier
 
 
 class MergedItem(MExModel):
     """Base model class definition for all merged items."""
-
-    if TYPE_CHECKING:
-        stableTargetId: Identifier
 
     @classmethod
     def get_entity_type(cls) -> str:

--- a/mex/common/models/merged_item.py
+++ b/mex/common/models/merged_item.py
@@ -1,8 +1,14 @@
+from typing import TYPE_CHECKING
+
 from mex.common.models.base import MExModel
+from mex.common.types import Identifier
 
 
 class MergedItem(MExModel):
     """Base model class definition for all merged items."""
+
+    if TYPE_CHECKING:
+        stableTargetId: Identifier
 
     @classmethod
     def get_entity_type(cls) -> str:

--- a/mex/common/organigram/extract.py
+++ b/mex/common/organigram/extract.py
@@ -2,7 +2,7 @@ import json
 from typing import Generator, Iterable
 
 from mex.common.logging import watch
-from mex.common.models.organizational_unit import ExtractedOrganizationalUnit
+from mex.common.models import ExtractedOrganizationalUnit
 from mex.common.organigram.models import OrganigramUnit
 from mex.common.settings import BaseSettings
 from mex.common.types import Identifier, Text

--- a/mex/common/organigram/models.py
+++ b/mex/common/organigram/models.py
@@ -1,6 +1,6 @@
 from pydantic import AnyUrl
 
-from mex.common.models.base import BaseModel
+from mex.common.models import BaseModel
 
 
 class OrganigramName(BaseModel):

--- a/mex/common/organigram/transform.py
+++ b/mex/common/organigram/transform.py
@@ -1,7 +1,7 @@
 from typing import Generator, Iterable
 
 from mex.common.logging import watch
-from mex.common.models.organizational_unit import ExtractedOrganizationalUnit
+from mex.common.models import ExtractedOrganizationalUnit
 from mex.common.organigram.models import OrganigramUnit
 from mex.common.types import Identifier, OrganizationalUnitID, Text, TextLanguage
 

--- a/mex/common/primary_source/models.py
+++ b/mex/common/primary_source/models.py
@@ -5,7 +5,7 @@ from sqlalchemy import Column, ForeignKey, Integer, Text
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.decl_api import DeclarativeMeta
 
-from mex.common.models.base import BaseModel
+from mex.common.models import BaseModel
 
 if TYPE_CHECKING:  # pragma: no cover
 

--- a/mex/common/primary_source/transform.py
+++ b/mex/common/primary_source/transform.py
@@ -1,7 +1,7 @@
 import json
 from typing import Optional
 
-from mex.common.models.primary_source import ExtractedPrimarySource
+from mex.common.models import ExtractedPrimarySource
 from mex.common.primary_source.models import MExDBPrimarySource
 from mex.common.types import Identifier, Link, Text
 

--- a/mex/common/public_api/connector.py
+++ b/mex/common/public_api/connector.py
@@ -12,7 +12,7 @@ from requests.exceptions import HTTPError, RequestException
 
 from mex.common.connector import BaseConnector
 from mex.common.logging import echo
-from mex.common.models import ExtractedData, MergedItem, MExModel
+from mex.common.models import MExModel
 from mex.common.public_api.models import (
     PublicApiAuthResponse,
     PublicApiAxisConstraint,
@@ -215,7 +215,7 @@ class PublicApiConnector(BaseConnector):  # pragma: no cover
         return []
 
     def post_models(
-        self, models: list[ExtractedData | MergedItem], wait_for_done: bool = True
+        self, models: list[MExModel], wait_for_done: bool = True
     ) -> list[Identifier]:
         """Convert models to public API items and post them.
 
@@ -298,7 +298,7 @@ class PublicApiConnector(BaseConnector):  # pragma: no cover
 
     def search_model(
         self, model_cls: type[ModelT], identifier: Identifier
-    ) -> ExtractedData | MergedItem | None:
+    ) -> MExModel | None:
         """Get an item from the Public API and convert it to a model.
 
         Args:
@@ -354,7 +354,10 @@ class PublicApiConnector(BaseConnector):  # pragma: no cover
         return None
 
     def search_items(
-        self, model_cls: type[MExModel], offset: int = 0, limit: int = 10
+        self,
+        model_cls: type[MExModel],
+        offset: int = 0,
+        limit: int = 10,
     ) -> list[PublicApiItem]:
         """Get all Public API items corresponding to `model_cls` with pagination.
 

--- a/mex/common/public_api/connector.py
+++ b/mex/common/public_api/connector.py
@@ -12,7 +12,7 @@ from requests.exceptions import HTTPError, RequestException
 
 from mex.common.connector import BaseConnector
 from mex.common.logging import echo
-from mex.common.models.base import MExModel
+from mex.common.models import ExtractedData, MergedItem, MExModel
 from mex.common.public_api.models import (
     PublicApiAuthResponse,
     PublicApiAxisConstraint,
@@ -215,12 +215,12 @@ class PublicApiConnector(BaseConnector):  # pragma: no cover
         return []
 
     def post_models(
-        self, models: list[MExModel], wait_for_done: bool = True
+        self, models: list[ExtractedData | MergedItem], wait_for_done: bool = True
     ) -> list[Identifier]:
         """Convert models to public API items and post them.
 
         Args:
-            models: MEx models to post
+            models: Extracted or merged models to post
             wait_for_done: If the return should block until the job is done
 
         Raises:
@@ -253,7 +253,7 @@ class PublicApiConnector(BaseConnector):  # pragma: no cover
         request = PublicApiSearchRequest(
             offset=0,
             limit=1,
-            facetConstraints=[
+            axisConstraints=[
                 PublicApiAxisConstraint(values=[str(identifier)], axis="identifier"),
                 PublicApiAxisConstraint(
                     values=[model_cls.get_entity_type()], axis="entityName"
@@ -298,7 +298,7 @@ class PublicApiConnector(BaseConnector):  # pragma: no cover
 
     def search_model(
         self, model_cls: type[ModelT], identifier: Identifier
-    ) -> MExModel | None:
+    ) -> ExtractedData | MergedItem | None:
         """Get an item from the Public API and convert it to a model.
 
         Args:
@@ -306,7 +306,7 @@ class PublicApiConnector(BaseConnector):  # pragma: no cover
             identifier: Identifier of the model
 
         Returns:
-            MEx model instance, if ID was found, else None
+            Extracted or merged model instance, if ID was found, else None
         """
         if item := self.search_item(model_cls, identifier):
             return transform_public_api_item_to_mex_model(item)
@@ -372,7 +372,7 @@ class PublicApiConnector(BaseConnector):  # pragma: no cover
         request = PublicApiSearchRequest(
             offset=offset,
             limit=limit,
-            facetConstraints=[
+            axisConstraints=[
                 PublicApiAxisConstraint(
                     values=[model_cls.get_entity_type()], axis="entityName"
                 )

--- a/mex/common/public_api/models.py
+++ b/mex/common/public_api/models.py
@@ -70,6 +70,11 @@ class PublicApiItem(PublicApiBaseModel):
     businessId: str
     values: list[PublicApiField] = Field(..., include=True)
 
+    @property
+    def stableTargetId(self) -> Identifier:
+        """Return the stableTargetId of this item."""
+        return Identifier(self.businessId.removesuffix("#"))
+
 
 class PublicApiSearchResponse(PublicApiBaseModel):
     """Response body that is expected for search results."""

--- a/mex/common/public_api/models.py
+++ b/mex/common/public_api/models.py
@@ -4,8 +4,15 @@ from uuid import UUID
 
 from pydantic import Extra, Field, validator
 
-from mex.common.models.base import BaseModel
-from mex.common.types import Link, LinkLanguage, Text, TextLanguage, Timestamp
+from mex.common.models import BaseModel
+from mex.common.types import (
+    Identifier,
+    Link,
+    LinkLanguage,
+    Text,
+    TextLanguage,
+    Timestamp,
+)
 
 PublicApiFieldValueTypes = UUID | Enum | Timestamp | str | Link | Text
 PublicApiFieldValueTypesOrList = (
@@ -60,6 +67,7 @@ class PublicApiItem(PublicApiBaseModel):
 
     entityType: str = Field(..., include=True)
     itemId: UUID | None
+    businessId: str
     values: list[PublicApiField] = Field(..., include=True)
 
 
@@ -84,6 +92,12 @@ class PublicApiItemWithoutValues(PublicApiBaseModel):
 
     entityType: str = Field(..., include=True)
     itemId: UUID | None
+    businessId: str
+
+    @property
+    def stableTargetId(self) -> Identifier:
+        """Return the stableTargetId of this item."""
+        return Identifier(self.businessId.removesuffix("#"))
 
 
 class PublicApiMetadataItemsResponse(PublicApiBaseModel):

--- a/mex/common/public_api/transform.py
+++ b/mex/common/public_api/transform.py
@@ -3,8 +3,7 @@ from collections import defaultdict
 from mex.common.models import (
     EXTRACTED_MODEL_CLASSES_BY_NAME,
     MERGED_MODEL_CLASSES_BY_NAME,
-    ExtractedData,
-    MergedItem,
+    MExModel,
 )
 from mex.common.public_api.models import (
     PublicApiField,
@@ -14,9 +13,7 @@ from mex.common.public_api.models import (
 from mex.common.types import Link, LinkLanguage, Text, TextLanguage
 
 
-def transform_mex_model_to_public_api_item(
-    model: ExtractedData | MergedItem,
-) -> PublicApiItem:
+def transform_mex_model_to_public_api_item(model: MExModel) -> PublicApiItem:
     """Convert a ExtractedData instance into a Public API item.
 
     Args:
@@ -55,16 +52,16 @@ def transform_mex_model_to_public_api_item(
 
 def transform_public_api_item_to_mex_model(
     api_item: PublicApiItem,
-) -> ExtractedData | MergedItem | None:
+) -> MExModel | None:
     """Try to convert a Public API item into an extracted data instance.
 
     Args:
         api_item: Public API item
 
     Returns:
-        Instance of a ExtractedData or MergedItem or None if unknown type
+        Transformed model or None if unknown type
     """
-    classes_by_name: dict[str, type[ExtractedData] | type[MergedItem]] = dict(
+    classes_by_name: dict[str, type[MExModel]] = dict(
         **EXTRACTED_MODEL_CLASSES_BY_NAME, **MERGED_MODEL_CLASSES_BY_NAME
     )
     cls = classes_by_name.get(api_item.entityType)

--- a/mex/common/scripts/schema.py
+++ b/mex/common/scripts/schema.py
@@ -5,7 +5,7 @@ from pydantic.schema import schema
 
 from mex.common.cli import entrypoint
 from mex.common.logging import echo
-from mex.common.models import MODEL_CLASSES
+from mex.common.models import EXTRACTED_MODEL_CLASSES
 from mex.common.settings import BaseSettings
 from mex.common.transform import MExEncoder
 from mex.common.types import WorkPath
@@ -36,7 +36,7 @@ def dump_schema() -> None:
     """
     settings = SchemaScriptsSettings.get()
     mex_schema = schema(
-        models=MODEL_CLASSES,
+        models=EXTRACTED_MODEL_CLASSES,
         title=settings.schema_title,
     )
 

--- a/mex/common/sinks/backend_api.py
+++ b/mex/common/sinks/backend_api.py
@@ -2,14 +2,14 @@ from typing import Generator, Iterable
 
 from mex.common.backend_api.connector import BackendApiConnector
 from mex.common.logging import watch
-from mex.common.models import ExtractedData, MergedItem
+from mex.common.models import MExModel
 from mex.common.types import Identifier
 from mex.common.utils import grouper
 
 
 @watch
 def post_to_backend_api(
-    models: Iterable[ExtractedData | MergedItem], chunk_size: int = 100
+    models: Iterable[MExModel], chunk_size: int = 100
 ) -> Generator[Identifier, None, None]:
     """Load models to the Backend API using bulk insertion.
 

--- a/mex/common/sinks/backend_api.py
+++ b/mex/common/sinks/backend_api.py
@@ -2,19 +2,19 @@ from typing import Generator, Iterable
 
 from mex.common.backend_api.connector import BackendApiConnector
 from mex.common.logging import watch
-from mex.common.models.base import MExModel
+from mex.common.models import ExtractedData, MergedItem
 from mex.common.types import Identifier
 from mex.common.utils import grouper
 
 
 @watch
 def post_to_backend_api(
-    models: Iterable[MExModel], chunk_size: int = 100
+    models: Iterable[ExtractedData | MergedItem], chunk_size: int = 100
 ) -> Generator[Identifier, None, None]:
     """Load models to the Backend API using bulk insertion.
 
     Args:
-        models: Iterable of MEx models
+        models: Iterable of extracted or merged models
         chunk_size: Optional size to chunks to post in one request
 
     Returns:

--- a/mex/common/sinks/load.py
+++ b/mex/common/sinks/load.py
@@ -1,7 +1,7 @@
 from typing import Callable, Iterable
 
 from mex.common.exceptions import MExError
-from mex.common.models.base import MExModel
+from mex.common.models import MExModel
 from mex.common.settings import BaseSettings
 from mex.common.sinks import Sink
 from mex.common.sinks.backend_api import post_to_backend_api

--- a/mex/common/sinks/ndjson.py
+++ b/mex/common/sinks/ndjson.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import IO, Any, Generator, Iterable
 
 from mex.common.logging import echo, watch
-from mex.common.models.base import MExModel
+from mex.common.models import MExModel
 from mex.common.settings import BaseSettings
 from mex.common.transform import MExEncoder
 from mex.common.types import Identifier

--- a/mex/common/sinks/public_api.py
+++ b/mex/common/sinks/public_api.py
@@ -1,7 +1,7 @@
 from typing import Generator, Iterable
 
 from mex.common.logging import watch
-from mex.common.models import ExtractedData, MergedItem, MExModel
+from mex.common.models import MExModel
 from mex.common.public_api.connector import PublicApiConnector
 from mex.common.public_api.models import PublicApiItem, PublicApiItemWithoutValues
 from mex.common.types import Identifier
@@ -10,7 +10,7 @@ from mex.common.utils import grouper
 
 @watch
 def post_to_public_api(
-    models: Iterable[ExtractedData | MergedItem], chunk_size: int = 100
+    models: Iterable[MExModel], chunk_size: int = 100
 ) -> Generator[Identifier, None, None]:
     """Load models to the Public API using bulk insertion.
 

--- a/mex/common/sinks/public_api.py
+++ b/mex/common/sinks/public_api.py
@@ -1,7 +1,7 @@
 from typing import Generator, Iterable
 
 from mex.common.logging import watch
-from mex.common.models.base import MExModel
+from mex.common.models import ExtractedData, MergedItem, MExModel
 from mex.common.public_api.connector import PublicApiConnector
 from mex.common.public_api.models import PublicApiItem, PublicApiItemWithoutValues
 from mex.common.types import Identifier
@@ -10,12 +10,12 @@ from mex.common.utils import grouper
 
 @watch
 def post_to_public_api(
-    models: Iterable[MExModel], chunk_size: int = 100
+    models: Iterable[ExtractedData | MergedItem], chunk_size: int = 100
 ) -> Generator[Identifier, None, None]:
     """Load models to the Public API using bulk insertion.
 
     Args:
-        models: Iterable of MEx models
+        models: Iterable of extracted or merged models
         chunk_size: Optional size to chunks to post in one request
 
     Returns:

--- a/mex/common/sinks/purge.py
+++ b/mex/common/sinks/purge.py
@@ -1,7 +1,7 @@
 from typing import Any, Callable, Iterable, Union
 
 from mex.common.exceptions import MExError
-from mex.common.models.base import MExModel
+from mex.common.models import MExModel
 from mex.common.public_api.models import PublicApiItem, PublicApiItemWithoutValues
 from mex.common.settings import BaseSettings
 from mex.common.sinks import Sink

--- a/mex/common/wikidata/transform.py
+++ b/mex/common/wikidata/transform.py
@@ -1,7 +1,6 @@
 from typing import Generator, Iterable
 
-from mex.common.models.organization import ExtractedOrganization
-from mex.common.models.primary_source import ExtractedPrimarySource
+from mex.common.models import ExtractedOrganization, ExtractedPrimarySource
 from mex.common.types import Text, TextLanguage
 from mex.common.wikidata.models.organization import (
     Aliases,

--- a/poetry.lock
+++ b/poetry.lock
@@ -707,13 +707,13 @@ files = [
 
 [[package]]
 name = "invoke"
-version = "2.1.3"
+version = "2.2.0"
 description = "Pythonic task execution"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "invoke-2.1.3-py3-none-any.whl", hash = "sha256:51e86a08d964160e01c44eccd22f50b25842bd96a9c63c11177032594cb86740"},
-    {file = "invoke-2.1.3.tar.gz", hash = "sha256:a3b15d52d50bbabd851b8a39582c772180b614000fa1612b4d92484d54d38c6b"},
+    {file = "invoke-2.2.0-py3-none-any.whl", hash = "sha256:6ea924cc53d4f78e3d98bc436b08069a03077e6f85ad1ddaa8a116d7dad15820"},
+    {file = "invoke-2.2.0.tar.gz", hash = "sha256:ee6cbb101af1a859c7fe84f2a264c059020b0cb7fe3535f9424300ab568f6bd5"},
 ]
 
 [[package]]
@@ -1728,13 +1728,13 @@ sqlcipher = ["sqlcipher3-binary"]
 
 [[package]]
 name = "sqlalchemy2-stubs"
-version = "0.0.2a34"
+version = "0.0.2a35"
 description = "Typing Stubs for SQLAlchemy 1.4"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "sqlalchemy2-stubs-0.0.2a34.tar.gz", hash = "sha256:2432137ab2fde1a608df4544f6712427b0b7ff25990cfbbc5a9d1db6c8c6f489"},
-    {file = "sqlalchemy2_stubs-0.0.2a34-py3-none-any.whl", hash = "sha256:a313220ac793404349899faf1272e821a62dbe1d3a029bd444faa8d3e966cd07"},
+    {file = "sqlalchemy2-stubs-0.0.2a35.tar.gz", hash = "sha256:bd5d530697d7e8c8504c7fe792ef334538392a5fb7aa7e4f670bfacdd668a19d"},
+    {file = "sqlalchemy2_stubs-0.0.2a35-py3-none-any.whl", hash = "sha256:593784ff9fc0dc2ded1895e3322591689db3be06f3ca006e3ef47640baf2d38a"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mex-common"
-version = "0.9.1"
+version = "0.9.2"
 description = "RKI MEx common library."
 authors = ["RKI MEx Team <mex@rki.de>"]
 readme = "README.md"

--- a/tests/backend_api/test_connector.py
+++ b/tests/backend_api/test_connector.py
@@ -96,7 +96,7 @@ def test_request_error_mocked(monkeypatch: MonkeyPatch) -> None:
         connector.request("GET", "fail")
 
 
-def test_post_models(
+def test_post_models_mocked(
     monkeypatch: MonkeyPatch, extracted_person: ExtractedPerson
 ) -> None:
     mocked_send_request = MagicMock(
@@ -110,7 +110,7 @@ def test_post_models(
 
     assert mocked_send_request.call_args_list[-1] == call(
         "POST",
-        "http://localhost:8080/v0/entity",
+        "http://localhost:8080/v0/ingest",
         timeout=BackendApiConnector.TIMEOUT,
         headers={"Content-Type": "application/json"},
         data=Joker(),

--- a/tests/backend_api/test_connector.py
+++ b/tests/backend_api/test_connector.py
@@ -8,7 +8,7 @@ from requests import JSONDecodeError, Response
 from requests.exceptions import HTTPError
 
 from mex.common.backend_api.connector import BackendApiConnector
-from mex.common.models.person import ExtractedPerson
+from mex.common.models import ExtractedPerson
 from mex.common.testing import Joker
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ from uuid import UUID
 
 import pytest
 
-from mex.common.models.person import ExtractedPerson
+from mex.common.models import ExtractedPerson
 from mex.common.types import Email, Identifier
 
 pytest_plugins = ("mex.common.testing.plugin",)

--- a/tests/ldap/conftest.py
+++ b/tests/ldap/conftest.py
@@ -6,7 +6,7 @@ from ldap3 import Connection
 from pytest import MonkeyPatch
 
 from mex.common.ldap.connector import LDAPConnector
-from mex.common.models.primary_source import ExtractedPrimarySource
+from mex.common.models import ExtractedPrimarySource
 from mex.common.primary_source.extract import extract_mex_db_primary_source_by_id
 from mex.common.primary_source.transform import (
     transform_mex_db_primary_source_to_extracted_primary_source,

--- a/tests/ldap/test_transform.py
+++ b/tests/ldap/test_transform.py
@@ -9,8 +9,7 @@ from mex.common.ldap.transform import (
     analyse_person_string,
     transform_ldap_persons_to_mex_persons,
 )
-from mex.common.models.organizational_unit import ExtractedOrganizationalUnit
-from mex.common.models.primary_source import ExtractedPrimarySource
+from mex.common.models import ExtractedOrganizationalUnit, ExtractedPrimarySource
 from mex.common.testing import Joker
 
 

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -3,7 +3,8 @@ from typing import Any, Optional, Union
 
 import pytest
 
-from mex.common.models.base import BaseModel, FlatValueMap
+from mex.common.models import BaseModel
+from mex.common.models.base import FlatValueMap
 from mex.common.types import Timestamp
 
 

--- a/tests/models/test_extracted_data.py
+++ b/tests/models/test_extracted_data.py
@@ -5,8 +5,7 @@ import pytest
 from pydantic import ValidationError
 
 from mex.common.identity.connector import IdentityConnector
-from mex.common.models.base import BaseModel
-from mex.common.models.extracted_data import ExtractedData
+from mex.common.models import BaseModel, ExtractedData
 from mex.common.types import Identifier
 
 

--- a/tests/models/test_merged_item.py
+++ b/tests/models/test_merged_item.py
@@ -1,4 +1,4 @@
-from mex.common.models.merged_item import MergedItem
+from mex.common.models import MergedItem
 from mex.common.types import Identifier
 
 

--- a/tests/organigram/conftest.py
+++ b/tests/organigram/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mex.common.models.organizational_unit import ExtractedOrganizationalUnit
+from mex.common.models import ExtractedOrganizationalUnit
 from mex.common.organigram.models import (
     OrganigramName,
     OrganigramUnit,

--- a/tests/organigram/test_extract.py
+++ b/tests/organigram/test_extract.py
@@ -1,4 +1,4 @@
-from mex.common.models.organizational_unit import ExtractedOrganizationalUnit
+from mex.common.models import ExtractedOrganizationalUnit
 from mex.common.organigram.extract import (
     extract_oranigram_units,
     get_unit_merged_ids_by_emails,

--- a/tests/public_api/conftest.py
+++ b/tests/public_api/conftest.py
@@ -33,18 +33,22 @@ def mex_metadata_items_response() -> PublicApiMetadataItemsResponse:
             "items": [
                 {
                     "itemId": "00005da9-f653-4c9c-b123-7b555d36b0fd",
+                    "businessId": "bgmAz9QJ7IaHGNyMamwhUx",
                     "entityType": "Datum",
                 },
                 {
                     "itemId": "000054a2-b16a-4f4e-82d2-1a222dba41e6",
+                    "businessId": "hLRKpjTpCS06BniW1l2NcU",
                     "entityType": "ExtractedDatum",
                 },
                 {
                     "itemId": "000054a2-b16a-4f4e-82d2-1a222fba41e6",
+                    "businessId": "g5MAfZYmivhK1I2voBK5bO",
                     "entityType": "ExtractedPerson",
                 },
                 {
                     "itemId": "000054a3-b16a-4f4e-82d2-1a222fbc41e6",
+                    "businessId": "cOfkBGYSeIjcKCdDZJQ0yk",
                     "entityType": "Person",
                 },
             ],

--- a/tests/public_api/test_connector.py
+++ b/tests/public_api/test_connector.py
@@ -6,8 +6,8 @@ from uuid import UUID
 import pytest
 import requests
 
-from mex.common.models.activity import ActivityType, ExtractedActivity
-from mex.common.models.person import ExtractedPerson
+from mex.common.models import ExtractedActivity, ExtractedPerson
+from mex.common.models.activity import ActivityType
 from mex.common.public_api.connector import PublicApiConnector
 from mex.common.public_api.models import PublicApiMetadataItemsResponse
 from mex.common.settings import BaseSettings
@@ -171,6 +171,7 @@ def test_search_model_mocked(mocked_api_session: MagicMock) -> None:
                 {
                     "itemId": item_id,
                     "entityType": ExtractedActivity.get_entity_type(),
+                    "businessId": "vhK1I2voBK5bO12MAfZYmi",
                     "values": [
                         {
                             "fieldName": "abstract",
@@ -274,18 +275,22 @@ def test_get_all_items_mocked(
         "items": [
             {
                 "itemId": "00005da9-f653-4c9c-b123-7b555d36b0fd",
+                "businessId": "bgmAz9QJ7IaHGNyMamwhUx",
                 "entityType": "Datum",
             },
             {
                 "itemId": "000054a2-b16a-4f4e-82d2-1a222dba41e6",
+                "businessId": "hLRKpjTpCS06BniW1l2NcU",
                 "entityType": "ExtractedDatum",
             },
             {
                 "itemId": "000054a2-b16a-4f4e-82d2-1a222fba41e6",
+                "businessId": "g5MAfZYmivhK1I2voBK5bO",
                 "entityType": "ExtractedPerson",
             },
             {
                 "itemId": "000054a3-b16a-4f4e-82d2-1a222fbc41e6",
+                "businessId": "cOfkBGYSeIjcKCdDZJQ0yk",
                 "entityType": "Person",
             },
         ],

--- a/tests/scripts/test_identity.py
+++ b/tests/scripts/test_identity.py
@@ -2,8 +2,7 @@ import pandas as pd
 import pytest
 from click.testing import CliRunner
 
-from mex.common.models.base import BaseModel
-from mex.common.models.extracted_data import ExtractedData
+from mex.common.models import BaseModel, ExtractedData
 from mex.common.scripts.identity import (
     IdentityScriptsSettings,
     export_identities,

--- a/tests/scripts/test_schema.py
+++ b/tests/scripts/test_schema.py
@@ -3,8 +3,8 @@ import json
 import pytest
 from click.testing import CliRunner
 
+from mex.common.models import ExtractedResource
 from mex.common.models.access_platform import TechnicalAccessibility
-from mex.common.models.resource import ExtractedResource
 from mex.common.scripts.schema import SchemaScriptsSettings, dump_schema
 
 

--- a/tests/sinks/test_backend_api.py
+++ b/tests/sinks/test_backend_api.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from pytest import MonkeyPatch
 
 from mex.common.backend_api.connector import BackendApiConnector
-from mex.common.models.person import ExtractedPerson
+from mex.common.models import ExtractedPerson
 from mex.common.sinks.backend_api import post_to_backend_api
 
 

--- a/tests/sinks/test_ndjson.py
+++ b/tests/sinks/test_ndjson.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from pydantic import UUID4
 
-from mex.common.models.base import MExModel
+from mex.common.models import MExModel
 from mex.common.settings import BaseSettings
 from mex.common.sinks.ndjson import write_ndjson
 from mex.common.types import Timestamp

--- a/tests/sinks/test_public_api.py
+++ b/tests/sinks/test_public_api.py
@@ -5,7 +5,7 @@ from uuid import UUID, uuid4
 import pytest
 from pytest import MonkeyPatch
 
-from mex.common.models.person import ExtractedPerson
+from mex.common.models import ExtractedPerson
 from mex.common.public_api.connector import PublicApiConnector
 from mex.common.sinks.public_api import post_to_public_api, purge_models_from_public_api
 from mex.common.types import Identifier

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -4,7 +4,7 @@ from io import StringIO
 from pytest import LogCaptureFixture
 
 from mex.common.extract import get_dtypes_for_model, parse_csv
-from mex.common.models.base import BaseModel
+from mex.common.models import BaseModel
 
 
 class DummyModel(BaseModel):

--- a/tests/wikidata/conftest.py
+++ b/tests/wikidata/conftest.py
@@ -5,7 +5,7 @@ import pytest
 import requests
 from pytest import MonkeyPatch
 
-from mex.common.models.primary_source import ExtractedPrimarySource
+from mex.common.models import ExtractedPrimarySource
 from mex.common.primary_source.extract import extract_mex_db_primary_source_by_id
 from mex.common.primary_source.transform import (
     transform_mex_db_primary_source_to_extracted_primary_source,

--- a/tests/wikidata/test_transform.py
+++ b/tests/wikidata/test_transform.py
@@ -1,7 +1,7 @@
 import json
 from operator import attrgetter, itemgetter
 
-from mex.common.models.primary_source import ExtractedPrimarySource
+from mex.common.models import ExtractedPrimarySource
 from mex.common.testing import Joker
 from mex.common.types import Text, TextLanguage
 from mex.common.wikidata.models.organization import (


### PR DESCRIPTION
- add businessId back to PublicApiModels
  - it is needed for the purge script
- prettify model imports by using `mex.common.models`
- fix public api queries by using axisConstraints (instead of deprecated facetConstraints)
- use new `/ingest` endpoint, instead of `/entities`
- fix typing of MExModel