### PR TITLE
feature/mx-1359 Dont auto-skip int tests in ci

### DIFF
--- a/mex/common/testing/plugin.py
+++ b/mex/common/testing/plugin.py
@@ -71,17 +71,16 @@ def isolate_connector_context() -> Generator[None, None, None]:
     reset_connector_context()
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def is_integration_test(request: FixtureRequest) -> bool:
     """Check the markers of a test to see if this is an integration test."""
     return any(m.name == "integration" for m in request.keywords.get("pytestmark", ()))
 
 
-@pytest.fixture(autouse=True)
-def skip_integration_test_in_ci(is_integration_test: bool) -> None:
-    """Automatically skip all tests marked as integration when the CI env var is set."""
-    if is_integration_test and os.environ.get("CI") == "true":  # pragma: no cover
-        pytest.skip("Skip integration test in CI")
+@pytest.fixture
+def in_continuous_integration() -> bool:
+    """Check the environment variable `CI` to determine whether we are in CI."""
+    return os.environ.get("CI") == "true"
 
 
 @pytest.fixture(autouse=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mex-common"
-version = "0.12.0"
+version = "0.12.1"
 description = "RKI MEx common library."
 authors = ["RKI MEx Team <mex@rki.de>"]
 readme = "README.md"


### PR DESCRIPTION
- disable auto-skipping integration tests in ci
  - mex-extractors already skips them https://github.com/robert-koch-institut/mex-extractors/blob/main/Makefile#L29
  - mex-drop will do so soon https://github.com/robert-koch-institut/mex-drop/pull/7
  - mex-backend soon will **want** to run int tests https://github.com/robert-koch-institut/mex-backend/pull/42
- instead, provide a fixture to check if we are in ci or not