### PR TITLE
handle 429 retries in http connector

### DIFF
--- a/mex/common/connector/http.py
+++ b/mex/common/connector/http.py
@@ -105,6 +105,11 @@ class HTTPConnector(BaseConnector):
         lambda response: cast(Response, response).status_code >= 500,
         max_tries=4,
     )
+    @backoff.on_predicate(
+        backoff.fibo,
+        lambda response: cast(Response, response).status_code == 429,
+        max_tries=10,
+    )
     @backoff.on_exception(backoff.fibo, RequestException, max_tries=6)
     def _send_request(
         self, method: str, url: str, params: dict[str, str] | None, **kwargs: Any


### PR DESCRIPTION
This PR:
- fixes http connector to handle 429 response explicitly. 