### PR TITLE
reformat name attributes as text in organigram

### DIFF
--- a/assets/raw-data/organigram/organizational_units.json
+++ b/assets/raw-data/organigram/organizational_units.json
@@ -1,33 +1,63 @@
 [
   {
     "alternativeName": [
-      "CHLD",
-      "C1 Sub-Unit",
-      "C1 Unterabteilung"
+      {
+        "value": "CHLD"
+      },
+      {
+        "value": "C1 Sub-Unit"
+      },
+      {
+        "value": "C1 Unterabteilung"
+      }
     ],
     "identifier": "child-unit",
-    "name": {
-      "de": "CHLD Unterabteilung",
-      "en": "C1: Sub Unit"
-    },
+    "name": [
+      {
+        "language": "de",
+        "value": "CHLD Unterabteilung"
+      },
+      {
+        "language": "en",
+        "value": "C1: Sub Unit"
+      }
+    ],
     "parentUnit": "parent-unit",
-    "shortName": "C1"
+    "shortName": [
+      {
+        "value": "C1"
+      }
+    ]
   },
   {
     "alternativeName": [
-      "PRNT Abteilung",
-      "PARENT Dept."
+      {
+        "value": "PRNT Abteilung"
+      },
+      {
+        "value": "PARENT Dept."
+      }
     ],
     "email": [
       "pu@example.com",
       "PARENT@example.com"
     ],
     "identifier": "parent-unit",
-    "name": {
-      "de": "Abteilung",
-      "en": "Department"
-    },
-    "shortName": "PRNT",
+    "name": [
+      {
+        "language": "de",
+        "value": "Abteilung"
+      },
+      {
+        "language": "en",
+        "value": "Department"
+      }
+    ],
+    "shortName": [
+      {
+        "value": "PRNT"
+      }
+    ],
     "website": [
       {
         "language": "en",

--- a/mex/common/organigram/models.py
+++ b/mex/common/organigram/models.py
@@ -1,21 +1,14 @@
 from mex.common.models import BaseModel
-from mex.common.types import Link
-
-
-class OrganigramName(BaseModel):
-    """Organigram unit name translated in German and English."""
-
-    de: str
-    en: str
+from mex.common.types import Link, Text
 
 
 class OrganigramUnit(BaseModel):
     """Organizational units in the format of the organigram JSON file."""
 
-    shortName: str
+    shortName: list[Text]
     email: list[str] = []
     identifier: str
-    name: OrganigramName
-    alternativeName: list[str] = []
+    name: list[Text]
+    alternativeName: list[Text] = []
     parentUnit: None | str
     website: None | Link

--- a/mex/common/organigram/transform.py
+++ b/mex/common/organigram/transform.py
@@ -3,7 +3,7 @@ from typing import Generator, Iterable
 from mex.common.logging import watch
 from mex.common.models import ExtractedOrganizationalUnit, ExtractedPrimarySource
 from mex.common.organigram.models import OrganigramUnit
-from mex.common.types import Email, OrganizationalUnitID, Text, TextLanguage
+from mex.common.types import Email, OrganizationalUnitID
 
 
 @watch
@@ -26,13 +26,10 @@ def transform_organigram_units_to_organizational_units(
         extracted_unit = ExtractedOrganizationalUnit(  # type: ignore[call-arg]
             identifierInPrimarySource=unit.identifier,
             hadPrimarySource=primary_source.stableTargetId,
-            alternativeName=[Text(value=name) for name in unit.alternativeName],
+            alternativeName=unit.alternativeName if unit.alternativeName else [],
             email=[Email(email) for email in unit.email],
-            name=[
-                Text(value=unit.name.de, language=TextLanguage.DE),
-                Text(value=unit.name.en, language=TextLanguage.EN),
-            ],
-            shortName=[Text(value=unit.shortName)],
+            name=unit.name,
+            shortName=unit.shortName,
             website=[unit.website] if unit.website else [],
         )
         extracted_unit_by_id_in_primary_source[unit.identifier] = extracted_unit

--- a/tests/organigram/conftest.py
+++ b/tests/organigram/conftest.py
@@ -1,21 +1,28 @@
 import pytest
 
 from mex.common.models import ExtractedOrganizationalUnit, ExtractedPrimarySource
-from mex.common.organigram.models import OrganigramName, OrganigramUnit
+from mex.common.organigram.models import OrganigramUnit
 from mex.common.organigram.transform import (
     transform_organigram_units_to_organizational_units,
 )
-from mex.common.types import Link, LinkLanguage
+from mex.common.types import Link, LinkLanguage, Text
 
 
 @pytest.fixture
 def child_unit() -> OrganigramUnit:
     """Return a child unit corresponding to the test_data."""
     return OrganigramUnit(
-        shortName="C1",
-        alternativeName=["CHLD", "C1 Sub-Unit", "C1 Unterabteilung"],
+        shortName=[Text(value="C1")],
+        alternativeName=[
+            Text(value="CHLD"),
+            Text(value="C1 Sub-Unit"),
+            Text(value="C1 Unterabteilung"),
+        ],
         identifier="child-unit",
-        name=OrganigramName(de="CHLD Unterabteilung", en="C1: Sub Unit"),
+        name=[
+            Text(value="CHLD Unterabteilung", language="de"),
+            Text(value="C1: Sub Unit", language="en"),
+        ],
         parentUnit="parent-unit",
         website=None,
     )
@@ -38,10 +45,13 @@ def extracted_child_unit(
 def parent_unit() -> OrganigramUnit:
     """Return a parent unit corresponding to the test_data."""
     return OrganigramUnit(
-        shortName="PRNT",
-        alternativeName=["PRNT Abteilung", "PARENT Dept."],
+        shortName=[Text(value="PRNT")],
+        alternativeName=[Text(value="PRNT Abteilung"), Text(value="PARENT Dept.")],
         identifier="parent-unit",
-        name=OrganigramName(de="Abteilung", en="Department"),
+        name=[
+            Text(value="Abteilung", language="de"),
+            Text(value="Department", language="en"),
+        ],
         email=["pu@example.com", "PARENT@example.com"],
         website=Link(
             language=LinkLanguage.EN,


### PR DESCRIPTION
- The name, shortName and alternativeName attributes in the organigram are now formatted as model.Text types in the OrganigramUnit class.
- The dummy test data and the tests are updated accordingly.
