### PR TITLE
Feature/MX add identifierInPrimarySource to unit synonyms

### DIFF
--- a/mex/common/organigram/extract.py
+++ b/mex/common/organigram/extract.py
@@ -5,7 +5,7 @@ from mex.common.logging import watch
 from mex.common.models import ExtractedOrganizationalUnit
 from mex.common.organigram.models import OrganigramUnit
 from mex.common.settings import BaseSettings
-from mex.common.types import OrganizationalUnitID, Text
+from mex.common.types import OrganizationalUnitID
 
 
 @watch
@@ -26,7 +26,7 @@ def extract_organigram_units() -> Generator[OrganigramUnit, None, None]:
 
 def get_synonyms(
     extracted_unit: ExtractedOrganizationalUnit,
-) -> Generator[Text, None, None]:
+) -> Generator[str, None, None]:
     """Generate synonyms for a unit using its name fields.
 
     Args:
@@ -35,9 +35,14 @@ def get_synonyms(
     Returns:
         Generator with (possibly duplicate) synonyms
     """
-    yield from extracted_unit.name
-    yield from extracted_unit.shortName
-    yield from extracted_unit.alternativeName
+    yield extracted_unit.identifierInPrimarySource
+    for names in [
+        extracted_unit.name,
+        extracted_unit.shortName,
+        extracted_unit.alternativeName,
+    ]:
+        for name in names:
+            yield name.value
 
 
 def get_unit_merged_ids_by_synonyms(
@@ -54,7 +59,7 @@ def get_unit_merged_ids_by_synonyms(
         Mapping from unit synonyms to stableTargetIds
     """
     return {
-        synonym.value: extracted_unit.stableTargetId
+        synonym: extracted_unit.stableTargetId
         for extracted_unit in extracted_units
         for synonym in get_synonyms(extracted_unit)
     }

--- a/tests/organigram/test_extract.py
+++ b/tests/organigram/test_extract.py
@@ -31,10 +31,12 @@ def test_get_unit_merged_ids_by_synonyms(
         "C1: Sub Unit": child_id,
         "CHLD": child_id,
         "CHLD Unterabteilung": child_id,
+        "child-unit": child_id,
         "Department": parent_id,
         "PARENT Dept.": parent_id,
         "PRNT": parent_id,
         "PRNT Abteilung": parent_id,
+        "parent-unit": parent_id,
     }
 
 


### PR DESCRIPTION
This PR implements https://jira.rki.local/browse/MX-1420

You can now extract OrganizationalUnits by the identifierInPrimarySource.