### PR TITLE
feature/mx 1071 add backend api share authentication key support

### DIFF
--- a/mex/common/backend_api/connector.py
+++ b/mex/common/backend_api/connector.py
@@ -33,16 +33,18 @@ class BackendApiConnector(HTTPConnector):
         Returns:
             Identifiers of posted models
         """
+        settings = BaseSettings.get()
         response = self.request(
-            "POST",
-            "ingest",
-            {
+            method="POST",
+            endpoint="ingest",
+            payload={
                 entity_type: list(entities)
                 for entity_type, entities in groupby(
                     sorted(models, key=lambda e: e.get_entity_type()),
                     lambda e: e.get_entity_type(),
                 )
             },
+            headers={"X-API-Key": settings.backend_api_write_key},
         )
         insert_response = BulkInsertResponse.parse_obj(response)
         return insert_response.identifiers

--- a/mex/common/public_api/connector.py
+++ b/mex/common/public_api/connector.py
@@ -209,14 +209,10 @@ class PublicApiConnector(HTTPConnector):  # pragma: no cover
         try:
             response = self.request("GET", f"metadata/items/{identifier}")
         except HTTPError as error:
-            # if no rows in result set (error code 2)
-            if (
-                # bw-compat to rki-mex-metadata before rev 2486424
-                error.response.status_code == 500
-                and error.response.json().get("code") == 2
-            ) or error.response.status_code == 404:
+            # no rows in result set, return None
+            if error.response and error.response.status_code == 404:
                 return None
-            # Re-raise any unexpected errors
+            # re-raise any unexpected errors
             raise error
         else:
             return PublicApiItem.parse_obj(response)

--- a/mex/common/settings.py
+++ b/mex/common/settings.py
@@ -124,11 +124,6 @@ class BaseSettings(PydanticBaseSettings):
         description="Backend API key with write access to call POST/PUT endpoints",
         env="BACKEND_API_WRITE_KEY",
     )
-    backend_api_read_key: SecretStr = Field(
-        SecretStr("dummy_read_key"),
-        description="Backend API key with read access to call GET endpoints",
-        env="BACKEND_API_READ_KEY",
-    )
     verify_session: Union[bool, AssetsPath] = Field(
         True,
         description=(

--- a/mex/common/settings.py
+++ b/mex/common/settings.py
@@ -119,6 +119,16 @@ class BaseSettings(PydanticBaseSettings):
         description="MEx backend API url.",
         env="MEX_BACKEND_API_URL",
     )
+    backend_api_write_key: SecretStr = Field(
+        SecretStr("dummy_write_key"),
+        description="Backend API key with write access to call POST/PUT endpoints",
+        env="BACKEND_API_WRITE_KEY",
+    )
+    backend_api_read_key: SecretStr = Field(
+        SecretStr("dummy_read_key"),
+        description="Backend API key with read access to call GET endpoints",
+        env="BACKEND_API_READ_KEY",
+    )
     verify_session: Union[bool, AssetsPath] = Field(
         True,
         description=(

--- a/tests/backend_api/test_connector.py
+++ b/tests/backend_api/test_connector.py
@@ -1,6 +1,7 @@
 import json
 from unittest.mock import MagicMock, Mock, call
 
+from pydantic import SecretStr
 from pytest import MonkeyPatch
 
 from mex.common.backend_api.connector import BackendApiConnector
@@ -24,8 +25,12 @@ def test_post_models_mocked(
         "POST",
         "http://localhost:8080/v0/ingest",
         None,
+        headers={
+            "X-API-Key": SecretStr("dummy_write_key"),
+            "Accept": "application/json",
+            "User-Agent": "rki/mex",
+        },
         timeout=10,
-        headers={"Accept": "application/json", "User-Agent": "rki/mex"},
         data=Joker(),
     )
 


### PR DESCRIPTION
This PR:
- introduces the read/write shared authentication key support with mex-backend.
- update tests accordingly