### PR TITLE
feature/Make pytest import optional

### DIFF
--- a/mex/common/testing/plugin.py
+++ b/mex/common/testing/plugin.py
@@ -7,6 +7,7 @@ import os
 from enum import Enum
 from pathlib import Path
 from typing import Any, Generator
+from unittest.mock import MagicMock
 
 from langdetect import DetectorFactory
 from pydantic import AnyUrl
@@ -25,7 +26,8 @@ class NoOpPytest:
 
     FixtureRequest = Any
     MonkeyPatch = Any
-    fixture = lambda **_: lambda f: f  # noqa: E731
+    fixture = MagicMock()
+    mark = MagicMock()
 
 
 try:
@@ -80,13 +82,13 @@ def isolate_connector_context() -> Generator[None, None, None]:
     reset_connector_context()
 
 
-@pytest.fixture
+@pytest.fixture()
 def is_integration_test(request: pytest.FixtureRequest) -> bool:
     """Check the markers of a test to see if this is an integration test."""
     return any(m.name == "integration" for m in request.keywords.get("pytestmark", ()))
 
 
-@pytest.fixture
+@pytest.fixture()
 def in_continuous_integration() -> bool:
     """Check the environment variable `CI` to determine whether we are in CI."""
     return os.environ.get("CI") == "true"
@@ -104,7 +106,7 @@ def faker_session_locale() -> list[str]:
     return ["de_DE", "en_US"]
 
 
-@pytest.fixture
+@pytest.fixture()
 @pytest.mark.usefixtures("settings")
 def extracted_primary_sources() -> dict[str, ExtractedPrimarySource]:
     """Return a mapping from `identifierInPrimarySource` to ExtractedPrimarySources."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mex-common"
-version = "0.13.6"
+version = "0.13.7"
 description = "RKI MEx common library."
 authors = ["RKI MEx Team <mex@rki.de>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mex-common"
-version = "0.13.7"
+version = "0.14.0"
 description = "RKI MEx common library."
 authors = ["RKI MEx Team <mex@rki.de>"]
 readme = "README.md"


### PR DESCRIPTION
- `pytest` is a dev-dependency
- it might not be installed, eg for productive extractors
- this PR adds a safeguard for when `pytest` is not installed
- code in `mex.common.testing.plugin` won't work
  - but at least trying to import the module will not fail
  - this is essentials for codebase scanning, like dagster does