### PR TITLE
feature/mx-1590 deterministic identity provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changes
+- make memory identity provider deterministic (same input args results in same stableTargetId and Identifier)
 
 ### Deprecated
 

--- a/mex/common/identity/memory.py
+++ b/mex/common/identity/memory.py
@@ -27,6 +27,17 @@ class MemoryIdentityProvider(BaseProvider):
             )
         ]
 
+    @staticmethod
+    def _get_identifier(*args: str) -> Identifier:
+        """Get deterministic identifier based on args."""
+        seed_string = "\n".join(args)
+        hash_ = hashlib.md5(  # noqa: S324 identifier generation is not security related
+            seed_string.encode()
+        )
+        seed_hex = hash_.hexdigest()
+        seed_int = int(seed_hex, 16)
+        return Identifier.generate(seed=seed_int)
+
     def assign(
         self,
         had_primary_source: MergedPrimarySourceIdentifier,
@@ -60,17 +71,6 @@ class MemoryIdentityProvider(BaseProvider):
         )
         self._database.append(identity)
         return identity
-
-    @staticmethod
-    def _get_identifier(*args: str) -> Identifier:
-        """Get deterministic identifier based on args."""
-        seed_string = "\n".join(args)
-        hash_ = hashlib.md5(  # noqa: S324 identifier generation is not security related
-            seed_string.encode()
-        )
-        seed_hex = hash_.hexdigest()
-        seed_int = int(seed_hex, 16)
-        return Identifier.generate(seed=seed_int)
 
     def fetch(
         self,

--- a/mex/common/identity/memory.py
+++ b/mex/common/identity/memory.py
@@ -48,26 +48,29 @@ class MemoryIdentityProvider(BaseProvider):
         if identities:
             return identities[0]
 
-        def get_identifier(target_field: str) -> Identifier:
-            """Get deterministic identifier based on target field and func args."""
-            seed_string = (
-                f"{target_field}\n{had_primary_source}\n{identifier_in_primary_source}"
-            )
-            hash_ = hashlib.md5(  # noqa: S324 we do not use md5 security related
-                seed_string.encode()
-            )
-            seed_hex = hash_.hexdigest()
-            seed_int = int(seed_hex, 16)
-            return Identifier.generate(seed=seed_int)
-
         identity = Identity(
             hadPrimarySource=had_primary_source,
             identifierInPrimarySource=identifier_in_primary_source,
-            stableTargetId=get_identifier("stableTargetId"),
-            identifier=get_identifier("identifier"),
+            stableTargetId=self._get_identifier(
+                "stableTargetId", had_primary_source, identifier_in_primary_source
+            ),
+            identifier=self._get_identifier(
+                "identifier", had_primary_source, identifier_in_primary_source
+            ),
         )
         self._database.append(identity)
         return identity
+
+    @staticmethod
+    def _get_identifier(*args: str) -> Identifier:
+        """Get deterministic identifier based on args."""
+        seed_string = "\n".join(args)
+        hash_ = hashlib.md5(  # noqa: S324 identifier generation is not security related
+            seed_string.encode()
+        )
+        seed_hex = hash_.hexdigest()
+        seed_int = int(seed_hex, 16)
+        return Identifier.generate(seed=seed_int)
 
     def fetch(
         self,

--- a/mex/common/types/__init__.py
+++ b/mex/common/types/__init__.py
@@ -64,6 +64,7 @@ __all__ = (
     "AccessRestriction",
     "ActivityType",
     "AnonymizationPseudonymization",
+    "AnyMergedIdentifier",
     "AnyNestedModel",
     "APIType",
     "AssetsPath",

--- a/tests/identity/test_memory.py
+++ b/tests/identity/test_memory.py
@@ -3,6 +3,22 @@ from mex.common.testing import Joker
 from mex.common.types import MergedPrimarySourceIdentifier
 
 
+def test_get_identifier() -> None:
+    assert MemoryIdentityProvider._get_identifier(
+        "foo"
+    ) == MemoryIdentityProvider._get_identifier("foo")
+    assert MemoryIdentityProvider._get_identifier(
+        "foo"
+    ) != MemoryIdentityProvider._get_identifier("bar")
+    identifiers = [
+        MemoryIdentityProvider._get_identifier(arg1, arg2)
+        for arg1 in ["foo", "bar"]
+        for arg2 in ["a", "b", "c"]
+    ]
+    # make sure each combination of args results in a unique identifier
+    assert len(set(identifiers)) == len(identifiers)
+
+
 def test_assign() -> None:
     provider = MemoryIdentityProvider.get()
     had_primary_source = MergedPrimarySourceIdentifier("00000000000000")

--- a/tests/identity/test_memory.py
+++ b/tests/identity/test_memory.py
@@ -42,7 +42,7 @@ def test_assign() -> None:
         identifier=new_identity.identifier,
     )
 
-    provider.__exit__(None, None, None)
+    provider.close()
     provider = MemoryIdentityProvider.get()
     fresh_identity = provider.assign(had_primary_source, identifier_in_primary_source)
 

--- a/tests/identity/test_memory.py
+++ b/tests/identity/test_memory.py
@@ -26,6 +26,17 @@ def test_assign() -> None:
         identifier=new_identity.identifier,
     )
 
+    provider.__exit__(None, None, None)
+    provider = MemoryIdentityProvider.get()
+    fresh_identity = provider.assign(had_primary_source, identifier_in_primary_source)
+
+    assert fresh_identity.model_dump() == dict(
+        hadPrimarySource=had_primary_source,
+        identifierInPrimarySource=identifier_in_primary_source,
+        stableTargetId=new_identity.stableTargetId,
+        identifier=new_identity.identifier,
+    )
+
 
 def test_fetch_empty() -> None:
     provider = MemoryIdentityProvider.get()


### PR DESCRIPTION
# Changes
- make memory identity provider deterministic (same input args results in same stableTargetId and Identifier)
