### PR TITLE
feature/mx-1502 update wikidata and temporal entity precision

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,16 +3,16 @@ default_language_version:
   python: python3.11
 repos:
   - repo: https://github.com/psf/black
-    rev: 24.3.0
+    rev: 24.4.2
     hooks:
       - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.5
+    rev: v0.4.4
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: pretty-format-json
         name: json
@@ -28,7 +28,7 @@ repos:
       - id: fix-byte-order-marker
         name: byte-order
   - repo: https://github.com/pdm-project/pdm
-    rev: 2.13.2
+    rev: 2.15.2
     hooks:
       - id: pdm-lock-check
         name: pdm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- add `precision` keyword to TemporalEntity constructor
-- add transform function for single wikidata organization to extracted organization
-
 ### Changes
-
-- add tests for ldap.extract
 
 ### Deprecated
 
@@ -22,9 +17,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- fix ldap.extract.get_merged_ids_by_email
-
 ### Security
+
+## [0.25.0] - 2024-05-14
+
+### Added
+
+- add `precision` keyword to TemporalEntity constructor
+- add transform function for single wikidata organization to extracted organization
+
+### Changes
+
+- add tests for ldap.extract
+
+### Fixed
+
+- fix ldap.extract.get_merged_ids_by_email
 
 ## [0.24.0] - 2024-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - apply_precision method for TemporalEntity
+- transform single wikidata organization to extracted organization
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- apply_precision method for TemporalEntity
+
 ### Changes
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- apply_precision method for TemporalEntity
-- transform single wikidata organization to extracted organization
-
 ### Changes
 
 ### Deprecated
@@ -21,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+
+## [0.25.0] - 2024-05-14
+
+### Added
+
+- add `precision` keyword to TemporalEntity constructor
+- add transform function for single wikidata organization to extracted organization
 
 ## [0.24.0] - 2024-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- add `precision` keyword to TemporalEntity constructor
+- add transform function for single wikidata organization to extracted organization
+
 ### Changes
 
 - add tests for ldap.extract
@@ -22,13 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix ldap.extract.get_merged_ids_by_email
 
 ### Security
-
-## [0.25.0] - 2024-05-14
-
-### Added
-
-- add `precision` keyword to TemporalEntity constructor
-- add transform function for single wikidata organization to extracted organization
 
 ## [0.24.0] - 2024-04-12
 

--- a/mex/common/types/__init__.py
+++ b/mex/common/types/__init__.py
@@ -32,6 +32,7 @@ from mex.common.types.path import AssetsPath, PathWrapper, WorkPath
 from mex.common.types.sink import Sink
 from mex.common.types.temporal_entity import (
     CET,
+    TEMPORAL_ENTITY_CLASSES_BY_PRECISION,
     TEMPORAL_ENTITY_FORMATS_BY_PRECISION,
     UTC,
     TemporalEntity,
@@ -112,6 +113,7 @@ __all__ = (
     "Text",
     "TextLanguage",
     "Theme",
+    "TEMPORAL_ENTITY_CLASSES_BY_PRECISION",
     "TEMPORAL_ENTITY_FORMATS_BY_PRECISION",
     "TemporalEntity",
     "YearMonth",

--- a/mex/common/types/temporal_entity.py
+++ b/mex/common/types/temporal_entity.py
@@ -294,7 +294,9 @@ class TemporalEntity:
         """Render a presentation showing this is not just a datetime."""
         return f'{self.__class__.__name__}("{self}")'
 
-    def apply_precision(self, precision: TemporalEntityPrecision) -> Any:
+    def apply_precision(
+        self, precision: TemporalEntityPrecision
+    ) -> "YearMonthDay | TemporalEntity | YearMonth | YearMonthDayTime":
         """Apply precision on a temporal entity.
 
         When precision is set to Day, timezone info will be stripped.
@@ -303,6 +305,10 @@ class TemporalEntity:
             datetime_tz_stripped = self.date_time.replace(tzinfo=None)
             temporal_entity = TEMPORAL_ENTITY_CLASSES_BY_PRECISION[precision](
                 datetime_tz_stripped.date()
+            )
+        else:
+            temporal_entity = TEMPORAL_ENTITY_CLASSES_BY_PRECISION[precision](
+                self.date_time
             )
         temporal_entity.precision = precision
         return temporal_entity

--- a/mex/common/types/temporal_entity.py
+++ b/mex/common/types/temporal_entity.py
@@ -294,6 +294,19 @@ class TemporalEntity:
         """Render a presentation showing this is not just a datetime."""
         return f'{self.__class__.__name__}("{self}")'
 
+    def apply_precision(self, precision: TemporalEntityPrecision) -> Any:
+        """Apply precision on a temporal entity.
+
+        When precision is set to Day, timezone info will be stripped.
+        """
+        if precision not in TIME_PRECISIONS:
+            datetime_tz_stripped = self.date_time.replace(tzinfo=None)
+            temporal_entity = TEMPORAL_ENTITY_CLASSES_BY_PRECISION[precision](
+                datetime_tz_stripped.date()
+            )
+        temporal_entity.precision = precision
+        return temporal_entity
+
 
 class YearMonth(TemporalEntity):
     """Parser for temporal entities with year-precision or month-precision."""
@@ -346,3 +359,14 @@ class YearMonthDayTime(TemporalEntity):
         json_schema["examples"] = ["2022-09-30T20:48:35Z"]
         json_schema["format"] = "date-time"
         return json_schema
+
+
+TEMPORAL_ENTITY_CLASSES_BY_PRECISION = {
+    TemporalEntityPrecision.YEAR: YearMonth,
+    TemporalEntityPrecision.MONTH: YearMonth,
+    TemporalEntityPrecision.DAY: YearMonthDay,
+    TemporalEntityPrecision.HOUR: YearMonthDayTime,
+    TemporalEntityPrecision.MINUTE: YearMonthDayTime,
+    TemporalEntityPrecision.SECOND: YearMonthDayTime,
+    TemporalEntityPrecision.MICROSECOND: YearMonthDayTime,
+}

--- a/mex/common/wikidata/transform.py
+++ b/mex/common/wikidata/transform.py
@@ -16,6 +16,8 @@ def transform_wikidata_organizations_to_extracted_organizations(
 ) -> Generator[ExtractedOrganization, None, None]:
     """Transform wikidata organizations into ExtractedOrganizations.
 
+    Wikidata organizations without labels are skipped.
+
     Args:
         wikidata_organizations: Iterable of wikidata organization to be transformed
         wikidata_primary_source: Extracted primary source for wikidata
@@ -23,39 +25,13 @@ def transform_wikidata_organizations_to_extracted_organizations(
     Returns:
         Generator of ExtractedOrganizations
     """
-    for organization in wikidata_organizations:
-        labels = _get_clean_labels(organization.labels)
-        if not labels:
-            continue
-        yield ExtractedOrganization(  # type: ignore[call-arg]
-            wikidataId=f"https://www.wikidata.org/entity/{organization.identifier}",
-            officialName=labels,
-            shortName=_get_clean_short_names(organization.claims.short_name),
-            geprisId=[],
-            isniId=[
-                f"https://isni.org/isni/{claim.mainsnak.datavalue.value.text}".replace(
-                    " ", ""
-                )
-                for claim in organization.claims.isni_id
-            ],
-            gndId=[
-                f"https://d-nb.info/gnd/{claim.mainsnak.datavalue.value.text}"
-                for claim in organization.claims.gnd_id
-            ],
-            viafId=[
-                f"https://viaf.org/viaf/{claim.mainsnak.datavalue.value.text}"
-                for claim in organization.claims.viaf_id
-            ],
-            rorId=[
-                f"https://ror.org/{claim.mainsnak.datavalue.value.text}"
-                for claim in organization.claims.ror_id
-            ],
-            identifierInPrimarySource=organization.identifier,
-            hadPrimarySource=wikidata_primary_source.stableTargetId,
-            alternativeName=_get_alternative_names(
-                organization.claims.native_label, organization.aliases
-            ),
-        )
+    for wikidata_organization in wikidata_organizations:
+        if extracted_organization := (
+            transform_wikidata_organization_to_extracted_organization(
+                wikidata_organization, wikidata_primary_source
+            )
+        ):
+            yield extracted_organization
 
 
 def transform_wikidata_organization_to_extracted_organization(
@@ -63,6 +39,8 @@ def transform_wikidata_organization_to_extracted_organization(
     wikidata_primary_source: ExtractedPrimarySource,
 ) -> ExtractedOrganization | None:
     """Transform one wikidata organization into ExtractedOrganizations.
+
+    If no labels are found on the wikidata organization, `None` is returned instead.
 
     Args:
         wikidata_organization: wikidata organization to be transformed
@@ -74,7 +52,6 @@ def transform_wikidata_organization_to_extracted_organization(
     labels = _get_clean_labels(wikidata_organization.labels)
     if not labels:
         return None
-
     return ExtractedOrganization(  # type: ignore[call-arg]
         wikidataId=f"https://www.wikidata.org/entity/{wikidata_organization.identifier}",
         officialName=labels,

--- a/mex/common/wikidata/transform.py
+++ b/mex/common/wikidata/transform.py
@@ -69,7 +69,7 @@ def transform_wikidata_organization_to_extracted_organization(
         wikidata_primary_source: Extracted primary source for wikidata
 
     Returns:
-        Generator of ExtractedOrganizations
+        ExtractedOrganization or None
     """
     labels = _get_clean_labels(wikidata_organization.labels)
     if not labels:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mex-common"
-version = "0.25.0"
+version = "0.24.0"
 description = "Common library for MEx python projects."
 authors = [{ name = "MEx Team", email = "mex@rki.de" }]
 readme = { file = "README.md", content-type = "text/markdown" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mex-common"
-version = "0.24.0"
+version = "0.25.0"
 description = "Common library for MEx python projects."
 authors = [{ name = "MEx Team", email = "mex@rki.de" }]
 readme = { file = "README.md", content-type = "text/markdown" }

--- a/tests/types/test_temporal_entity.py
+++ b/tests/types/test_temporal_entity.py
@@ -9,6 +9,7 @@ from mex.common.types import (
     CET,
     UTC,
     TemporalEntity,
+    TemporalEntityPrecision,
     YearMonth,
     YearMonthDay,
     YearMonthDayTime,
@@ -195,3 +196,11 @@ def test_invalid_dates_throw_error() -> None:
 
     with pytest.raises(DateParseError):
         YearMonthDayTime("2018-03-02T12:61:01Z")
+
+
+def test_apply_precision() -> None:
+    temporal_entity = TemporalEntity(date(2022, 12, 25))
+    temporal_entity.apply_precision(TemporalEntityPrecision.DAY)
+
+    assert temporal_entity.date_time == datetime(2022, 12, 25, 0, 0)
+    assert temporal_entity.precision == TemporalEntityPrecision.DAY

--- a/tests/wikidata/test_transform.py
+++ b/tests/wikidata/test_transform.py
@@ -14,9 +14,65 @@ from mex.common.wikidata.transform import (
     _get_alternative_names,
     _get_clean_labels,
     _get_clean_short_names,
+    transform_wikidata_organization_to_extracted_organization,
     transform_wikidata_organizations_to_extracted_organizations,
 )
 from tests.wikidata.conftest import TESTDATA_DIR
+
+
+def test_transform_wikidata_organization_to_extracted_organization(
+    extracted_primary_sources: dict[str, ExtractedPrimarySource],
+) -> None:
+    expected = {
+        "identifier": Joker(),
+        "hadPrimarySource": Joker(),
+        "identifierInPrimarySource": "Q26678",
+        "stableTargetId": Joker(),
+        "alternativeName": [
+            {"value": "alias_en_3", "language": None},
+            {"value": "alias_de_2", "language": None},
+            {"value": "alias_en_1", "language": None},
+            {"value": "alias_en_2", "language": None},
+            {"value": "alias_de_1", "language": None},
+            {"value": "test_native_name", "language": TextLanguage.DE},
+            {"value": "alias_de_3", "language": None},
+            {"value": "alias_en_4", "language": None},
+        ],
+        "geprisId": [],
+        "gndId": ["https://d-nb.info/gnd/2005475-0"],
+        "isniId": ["https://isni.org/isni/000000012308257X"],
+        "officialName": [
+            Text(value="TEST", language=TextLanguage.EN),
+            Text(value="TEST", language=TextLanguage.DE),
+        ],
+        "rorId": ["https://ror.org/05vs9tj88", "https://ror.org/044kkbh92"],
+        "shortName": [],
+        "viafId": ["https://viaf.org/viaf/129013645"],
+        "wikidataId": ["https://www.wikidata.org/entity/Q26678"],
+    }
+    with open(TESTDATA_DIR / "items_details.json", encoding="utf-8") as f:
+        wikidata_organization = WikidataOrganization.model_validate(json.load(f)[0])
+
+    extracted_organization = transform_wikidata_organization_to_extracted_organization(
+        wikidata_organization, extracted_primary_sources["wikidata"]
+    )
+
+    assert extracted_organization
+
+    assert sorted(
+        extracted_organization.model_dump()["alternativeName"],
+        key=itemgetter("value"),
+    ) == sorted(expected["alternativeName"], key=itemgetter("value"))
+
+    assert (
+        extracted_organization.model_dump()["identifierInPrimarySource"]
+        == expected["identifierInPrimarySource"]
+    )
+    assert extracted_organization.model_dump()["rorId"] == expected["rorId"]
+    assert extracted_organization.model_dump()["wikidataId"] == expected["wikidataId"]
+    assert extracted_organization.model_dump()["gndId"] == expected["gndId"]
+    assert extracted_organization.model_dump()["isniId"] == expected["isniId"]
+    assert extracted_organization.model_dump()["viafId"] == expected["viafId"]
 
 
 def test_transform_wikidata_organization_to_organization(


### PR DESCRIPTION
# PR Context
- some prep for https://github.com/robert-koch-institut/mex-extractors/pull/52

# Added
- add `precision` keyword to TemporalEntity constructor
- add transform function for single wikidata organization to extracted organization



