### PR TITLE
isolate settings context before first test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- isolate settings context before first test
+
 ### Security
 
 ## [0.24.0] - 2024-04-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- isolate settings context before first test
-
 ### Security
+
+## [0.24.1] - 2024-04-17
+
+### Fixed
+
+- isolate settings context before first test
 
 ## [0.24.0] - 2024-04-12
 

--- a/mex/common/testing/plugin.py
+++ b/mex/common/testing/plugin.py
@@ -70,8 +70,11 @@ def settings() -> BaseSettings:
 
 
 @pytest.fixture(autouse=True)
-def isolate_settings() -> Generator[None, None, None]:
+def isolate_settings(
+    isolate_assets_dir: None, isolate_work_dir: None
+) -> Generator[None, None, None]:
     """Automatically reset the settings singleton store."""
+    SETTINGS_STORE.reset()
     yield
     SETTINGS_STORE.reset()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mex-common"
-version = "0.24.0"
+version = "0.24.1"
 description = "Common library for MEx python projects."
 authors = [{ name = "MEx Team", email = "mex@rki.de" }]
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
# PR Context
- blocked by: https://github.com/robert-koch-institut/mex-extractors/pull/39 as testing is only possible after the mex-common dependency in mex-extractors is updated to v0.24.0
- Bug: the first test that is executed does not receive isolated settings. It therefore receives the production data as they are in mex-assets. If the test uses data from mex-assets, it will get a different result than if it is not executed first.
- Reproduce: in mex-extractors, execute `pdm run pytest .\tests\sumo\test_extract.py::test_extract_cc1_data_model_nokeda`
  - passes if not executed as first test
  - fails if executed in isolation / as first test

# Fixed
- isolate settings context before first test

