### PR TITLE
feature/mx-1571 more rule preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- add static class attribute `stemType` to models, containing an unprefixed entityType
+- add `AnyRuleModel`, `RULE_MODEL_CLASSES`, `RULE_MODEL_CLASSES_BY_NAME` to models
+- add type aliases `AnyPrimitiveType` and `LiteralStringType` to types
+- add new utility function `ensure_postfix` for adding postfixes to strings
+
 ### Changes
+
+- clean-up and unify `mapping` and `filter` class generation
 
 ### Deprecated
 

--- a/mex/common/models/__init__.py
+++ b/mex/common/models/__init__.py
@@ -32,6 +32,8 @@ Each entity type `T` is modelled for the following use cases:
 Since these models for different use cases have a lot of overlapping attributes,
 we use a number of intermediate private classes to compose the public classes:
 
+- `_Stem` defines a static class attribute `stemType`, e.g. `Person` or `PrimarySource`,
+  which is added to all intermediate and exported classes
 - `_OptionalLists` defines all fields typed as lists with an arity of 0-n
 - `_RequiredLists` defines all fields typed as lists with an arity of 1-n
 - `_SparseLists` re-defines all fields from `_RequiredLists` with an arity of 0-n
@@ -101,7 +103,7 @@ from mex.common.models.extracted_data import (
     ExtractedData,
 )
 from mex.common.models.filter import generate_entity_filter_schema
-from mex.common.models.mapping import generate_mapping_schema_for_mex_class
+from mex.common.models.mapping import generate_mapping_schema
 from mex.common.models.merged_item import MergedItem
 from mex.common.models.organization import (
     AdditiveOrganization,
@@ -180,6 +182,7 @@ __all__ = (
     "AnyExtractedModel",
     "AnyMergedModel",
     "AnyPreventiveModel",
+    "AnyRuleModel",
     "AnySubtractiveModel",
     "BaseModel",
     "EXTRACTED_MODEL_CLASSES_BY_NAME",
@@ -227,6 +230,8 @@ __all__ = (
     "PreventiveRule",
     "PreventiveVariable",
     "PreventiveVariableGroup",
+    "RULE_MODEL_CLASSES_BY_NAME",
+    "RULE_MODEL_CLASSES",
     "SUBTRACTIVE_MODEL_CLASSES_BY_NAME",
     "SUBTRACTIVE_MODEL_CLASSES",
     "SubtractiveAccessPlatform",
@@ -359,12 +364,16 @@ PREVENTIVE_MODEL_CLASSES_BY_NAME: Final[dict[str, type[AnyPreventiveModel]]] = {
     cls.__name__: cls for cls in PREVENTIVE_MODEL_CLASSES
 }
 
+AnyRuleModel = AnyAdditiveModel | AnySubtractiveModel | AnyPreventiveModel
+RULE_MODEL_CLASSES: Final[list[type[AnyRuleModel]]] = list(get_args(AnyRuleModel))
+RULE_MODEL_CLASSES_BY_NAME: Final[dict[str, type[AnyRuleModel]]] = {
+    cls.__name__: cls for cls in RULE_MODEL_CLASSES
+}
+
 FILTER_MODEL_BY_EXTRACTED_CLASS_NAME = {
-    cls.__name__: generate_entity_filter_schema(mex_model_class=cls)
-    for cls in EXTRACTED_MODEL_CLASSES
+    cls.__name__: generate_entity_filter_schema(cls) for cls in EXTRACTED_MODEL_CLASSES
 }
 
 MAPPING_MODEL_BY_EXTRACTED_CLASS_NAME = {
-    cls.__name__: generate_mapping_schema_for_mex_class(mex_model_class=cls)
-    for cls in EXTRACTED_MODEL_CLASSES
+    cls.__name__: generate_mapping_schema(cls) for cls in EXTRACTED_MODEL_CLASSES
 }

--- a/mex/common/models/access_platform.py
+++ b/mex/common/models/access_platform.py
@@ -1,6 +1,6 @@
 """A way of physically accessing the Resource for re-use."""
 
-from typing import Annotated, Literal
+from typing import Annotated, ClassVar, Literal
 
 from pydantic import Field
 
@@ -26,9 +26,13 @@ from mex.common.types import (
 from mex.common.types.identifier import MergedPrimarySourceIdentifier
 
 
-class _OptionalLists(BaseModel):
-    """All list fields of an access platform that allow empty lists."""
+class _Stem(BaseModel):
+    stemType: ClassVar[Annotated[Literal["AccessPlatform"], Field(frozen=True)]] = (
+        "AccessPlatform"
+    )
 
+
+class _OptionalLists(_Stem):
     alternativeTitle: list[Text] = []
     contact: list[
         MergedOrganizationalUnitIdentifier
@@ -41,7 +45,7 @@ class _OptionalLists(BaseModel):
     unitInCharge: list[MergedOrganizationalUnitIdentifier] = []
 
 
-class _OptionalValues(BaseModel):
+class _OptionalValues(_Stem):
     endpointDescription: Link | None = None
     endpointType: (
         Annotated[APIType, Field(examples=["https://mex.rki.de/item/api-type-1"])]
@@ -50,21 +54,21 @@ class _OptionalValues(BaseModel):
     endpointURL: Link | None = None
 
 
-class _RequiredValues(BaseModel):
+class _RequiredValues(_Stem):
     technicalAccessibility: Annotated[
         TechnicalAccessibility,
         Field(examples=["https://mex.rki.de/item/technical-accessibility-1"]),
     ]
 
 
-class _SparseValues(BaseModel):
+class _SparseValues(_Stem):
     technicalAccessibility: Annotated[
         TechnicalAccessibility | None,
         Field(examples=["https://mex.rki.de/item/technical-accessibility-1"]),
     ] = None
 
 
-class _VariadicValues(BaseModel):
+class _VariadicValues(_Stem):
     endpointDescription: list[Link]
     endpointType: list[
         Annotated[APIType, Field(examples=["https://mex.rki.de/item/api-type-1"])]
@@ -119,7 +123,7 @@ class SubtractiveAccessPlatform(_OptionalLists, _VariadicValues, SubtractiveRule
     ] = "SubtractiveAccessPlatform"
 
 
-class PreventiveAccessPlatform(PreventiveRule):
+class PreventiveAccessPlatform(_Stem, PreventiveRule):
     """Rule to prevent primary sources for fields of merged access platform items."""
 
     entityType: Annotated[

--- a/mex/common/models/activity.py
+++ b/mex/common/models/activity.py
@@ -3,7 +3,7 @@
 This may be a project, an area of work or an administrative procedure.
 """
 
-from typing import Annotated, Literal
+from typing import Annotated, ClassVar, Literal
 
 from pydantic import Field
 
@@ -32,8 +32,11 @@ from mex.common.types import (
 )
 
 
-class _OptionalLists(BaseModel):
+class _Stem(BaseModel):
+    stemType: ClassVar[Annotated[Literal["Activity"], Field(frozen=True)]] = "Activity"
 
+
+class _OptionalLists(_Stem):
     abstract: list[Text] = []
     activityType: list[
         Annotated[
@@ -59,7 +62,7 @@ class _OptionalLists(BaseModel):
     website: list[Link] = []
 
 
-class _RequiredLists(BaseModel):
+class _RequiredLists(_Stem):
     contact: Annotated[
         list[
             MergedOrganizationalUnitIdentifier
@@ -74,7 +77,7 @@ class _RequiredLists(BaseModel):
     title: Annotated[list[Text], Field(min_length=1)]
 
 
-class _SparseLists(BaseModel):
+class _SparseLists(_Stem):
     contact: list[
         MergedOrganizationalUnitIdentifier
         | MergedPersonIdentifier
@@ -123,7 +126,7 @@ class SubtractiveActivity(_OptionalLists, _SparseLists, SubtractiveRule):
     ] = "SubtractiveActivity"
 
 
-class PreventiveActivity(PreventiveRule):
+class PreventiveActivity(_Stem, PreventiveRule):
     """Rule to prevent primary sources for fields of merged activity items."""
 
     entityType: Annotated[

--- a/mex/common/models/contact_point.py
+++ b/mex/common/models/contact_point.py
@@ -1,6 +1,6 @@
 """A contact point - for example, an interdepartmental project."""
 
-from typing import Annotated, Literal
+from typing import Annotated, ClassVar, Literal
 
 from pydantic import Field
 
@@ -20,11 +20,17 @@ from mex.common.types import (
 )
 
 
-class _RequiredLists(BaseModel):
+class _Stem(BaseModel):
+    stemType: ClassVar[Annotated[Literal["ContactPoint"], Field(frozen=True)]] = (
+        "ContactPoint"
+    )
+
+
+class _RequiredLists(_Stem):
     email: Annotated[list[Email], Field(min_length=1)]
 
 
-class _SparseLists(BaseModel):
+class _SparseLists(_Stem):
     email: list[Email] = []
 
 
@@ -67,7 +73,7 @@ class SubtractiveContactPoint(_SparseLists, SubtractiveRule):
     ] = "SubtractiveContactPoint"
 
 
-class PreventiveContactPoint(PreventiveRule):
+class PreventiveContactPoint(_Stem, PreventiveRule):
     """Rule to prevent primary sources for fields of merged contact point items."""
 
     entityType: Annotated[

--- a/mex/common/models/distribution.py
+++ b/mex/common/models/distribution.py
@@ -1,6 +1,6 @@
 """A specific representation of a dataset."""
 
-from typing import Annotated, Literal
+from typing import Annotated, ClassVar, Literal
 
 from pydantic import Field
 
@@ -25,7 +25,13 @@ from mex.common.types import (
 )
 
 
-class _OptionalLists(BaseModel):
+class _Stem(BaseModel):
+    stemType: ClassVar[Annotated[Literal["Distribution"], Field(frozen=True)]] = (
+        "Distribution"
+    )
+
+
+class _OptionalLists(_Stem):
     author: list[MergedPersonIdentifier] = []
     contactPerson: list[MergedPersonIdentifier] = []
     dataCurator: list[MergedPersonIdentifier] = []
@@ -36,15 +42,15 @@ class _OptionalLists(BaseModel):
     researcher: list[MergedPersonIdentifier] = []
 
 
-class _RequiredLists(BaseModel):
+class _RequiredLists(_Stem):
     publisher: Annotated[list[MergedOrganizationIdentifier], Field(min_length=1)]
 
 
-class _SparseLists(BaseModel):
+class _SparseLists(_Stem):
     publisher: list[MergedOrganizationIdentifier] = []
 
 
-class _OptionalValues(BaseModel):
+class _OptionalValues(_Stem):
     accessService: MergedAccessPlatformIdentifier | None = None
     accessURL: Link | None = None
     downloadURL: Link | None = None
@@ -63,7 +69,7 @@ class _OptionalValues(BaseModel):
     modified: YearMonthDayTime | YearMonthDay | YearMonth | None = None
 
 
-class _RequiredValues(BaseModel):
+class _RequiredValues(_Stem):
     accessRestriction: Annotated[
         AccessRestriction,
         Field(examples=["https://mex.rki.de/item/access-restriction-1"]),
@@ -78,7 +84,7 @@ class _RequiredValues(BaseModel):
     ]
 
 
-class _SparseValues(BaseModel):
+class _SparseValues(_Stem):
     accessRestriction: (
         Annotated[
             AccessRestriction,
@@ -99,7 +105,7 @@ class _SparseValues(BaseModel):
     ) = None
 
 
-class _VariadicValues(BaseModel):
+class _VariadicValues(_Stem):
     accessRestriction: list[
         Annotated[
             AccessRestriction,
@@ -163,7 +169,7 @@ class SubtractiveDistribution(
     ] = "SubtractiveDistribution"
 
 
-class PreventiveDistribution(PreventiveRule):
+class PreventiveDistribution(_Stem, PreventiveRule):
     """Rule to prevent primary sources for fields of merged distribution items."""
 
     entityType: Annotated[

--- a/mex/common/models/entity.py
+++ b/mex/common/models/entity.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from mex.common.models.base import BaseModel
 from mex.common.types import Identifier
@@ -7,18 +7,25 @@ from mex.common.types import Identifier
 class BaseEntity(BaseModel, extra="forbid"):
     """Abstract base model for extracted data, merged item and rule set classes.
 
-    This class gives type hints for an `identifier` field and the frozen class variable
-    `entityType`. Subclasses should implement both fields and set the correct identifier
-    type as well as the correct literal value for the entity type.
+    This class gives type hints for an `identifier` field, the frozen `entityType` field
+    and the frozen class variable `stemType`.
+    Subclasses should implement all three fields while setting the correct identifier
+    type as well as the correct literal values for the entity and stem types.
     """
 
     if TYPE_CHECKING:  # pragma: no cover
-        # The `entityType` class variable is added to all `BaseEntity` subclasses to
+        # The frozen `entityType` field is added to all `BaseEntity` subclasses to
         # help with assigning the correct class when reading raw JSON entities.
         # E.g.: https://docs.pydantic.dev/latest/concepts/fields/#discriminator
         # Simple duck-typing would not work, because some entity-types have overlapping
         # attributes, like `Person.email` and `ContactPoint.email`.
         entityType: str
+
+        # The frozen `stemType` class variable is added to all `BaseEntity` subclasses
+        # to help with knowing which special-use-case classes are meant for the same
+        # type of items. E.g. `ExtractedPerson`, `MergedPerson` and `PreventivePerson`
+        # all share the same `stemType` of `Person`.
+        stemType: ClassVar
 
         # A globally unique identifier is added to all `BaseEntity` subclasses and
         # should be typed to the correct identifier type. Regardless of the entity-type

--- a/mex/common/models/filter.py
+++ b/mex/common/models/filter.py
@@ -2,6 +2,9 @@ from typing import Annotated, Any
 
 from pydantic import BaseModel, Field, create_model
 
+from mex.common.models import AnyExtractedModel
+from mex.common.transform import ensure_postfix
+
 
 class EntityFilterRule(BaseModel, extra="forbid"):
     """Entity filter rule model."""
@@ -21,24 +24,27 @@ class EntityFilter(BaseModel, extra="forbid"):
 
 
 def generate_entity_filter_schema(
-    mex_model_class: type[BaseModel],
+    extracted_model: type[AnyExtractedModel],
 ) -> type[BaseModel]:
-    """Create a mapping schema for an entity filter for a Mex model class.
+    """Create a mapping schema for an entity filter for an extracted model class.
 
     Example entity filter: If activity starts before 2016: do not extract.
 
     Args:
-        mex_model_class: a pydantic model (type) of a MEx model class/entity.
+        extracted_model: a pydantic model for an extracted model class
 
     Returns:
-        model of the mapping schema for an entity filter for a Mex model class.
+        model of the mapping schema for an entity filter
     """
-    filters: dict[str, Any] = {
-        f"{mex_model_class.__name__}": (list[EntityFilter], None)
+    fields: dict[str, Any] = {
+        extracted_model.__name__: (list[EntityFilter], None),
     }
-
+    entity_filter_name = ensure_postfix(extracted_model.stemType, "EntityFilter")
     entity_filter_model: type[BaseModel] = create_model(
-        f"{mex_model_class.__name__}",
-        **filters,
+        entity_filter_name,
+        **fields,
+    )
+    entity_filter_model.__doc__ = (
+        f"Schema for entity filters for the entity type {extracted_model.__name__}."
     )
     return entity_filter_model

--- a/mex/common/models/filter.py
+++ b/mex/common/models/filter.py
@@ -1,9 +1,11 @@
-from typing import Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 from pydantic import BaseModel, Field, create_model
 
-from mex.common.models import AnyExtractedModel
 from mex.common.transform import ensure_postfix
+
+if TYPE_CHECKING:  # pragma: no cover
+    from mex.common.models import AnyExtractedModel
 
 
 class EntityFilterRule(BaseModel, extra="forbid"):
@@ -24,7 +26,7 @@ class EntityFilter(BaseModel, extra="forbid"):
 
 
 def generate_entity_filter_schema(
-    extracted_model: type[AnyExtractedModel],
+    extracted_model: type["AnyExtractedModel"],
 ) -> type[BaseModel]:
     """Create a mapping schema for an entity filter for an extracted model class.
 

--- a/mex/common/models/mapping.py
+++ b/mex/common/models/mapping.py
@@ -1,9 +1,11 @@
-from typing import Annotated, Any, get_origin
+from typing import TYPE_CHECKING, Annotated, Any, get_origin
 
 from pydantic import BaseModel, Field, create_model
 
-from mex.common.models import AnyExtractedModel
 from mex.common.transform import ensure_postfix
+
+if TYPE_CHECKING:  # pragma: no cover
+    from mex.common.models import AnyExtractedModel
 
 
 class GenericRule(BaseModel, extra="forbid"):
@@ -25,7 +27,7 @@ class GenericField(BaseModel, extra="forbid"):
 
 
 def generate_mapping_schema(
-    extracted_model: type[AnyExtractedModel],
+    extracted_model: type["AnyExtractedModel"],
 ) -> type[BaseModel]:
     """Create a mapping schema the MEx extracted model class.
 

--- a/mex/common/models/mapping.py
+++ b/mex/common/models/mapping.py
@@ -2,7 +2,8 @@ from typing import Annotated, Any, get_origin
 
 from pydantic import BaseModel, Field, create_model
 
-from mex.common.models import ExtractedData
+from mex.common.models import AnyExtractedModel
+from mex.common.transform import ensure_postfix
 
 
 class GenericRule(BaseModel, extra="forbid"):
@@ -23,8 +24,8 @@ class GenericField(BaseModel, extra="forbid"):
     comment: str | None = None
 
 
-def generate_mapping_schema_for_mex_class(
-    mex_model_class: type[ExtractedData],
+def generate_mapping_schema(
+    extracted_model: type[AnyExtractedModel],
 ) -> type[BaseModel]:
     """Create a mapping schema the MEx extracted model class.
 
@@ -32,14 +33,14 @@ def generate_mapping_schema_for_mex_class(
     depending on the respective fields and their types.
 
     Args:
-        mex_model_class: a pydantic model (type) of a MEx model class/entity
+        extracted_model: a pydantic model for an extracted model class
 
     Returns:
         dynamic mapping model for the provided extracted model class
     """
     # dicts for create_model() must be declared as dict[str, Any] to silence mypy
-    field_models: dict[str, Any] = {}
-    for field_name, field_info in mex_model_class.model_fields.items():
+    fields: dict[str, Any] = {}
+    for field_name, field_info in extracted_model.model_fields.items():
         if field_name == "entityType":
             continue
         # first create dynamic rule model
@@ -69,13 +70,13 @@ def generate_mapping_schema_for_mex_class(
             f"Mapping schema for {field_name.capitalize()} fields in primary source."
         )
         if field_info.is_required():
-            field_models[field_name] = (list[field_model], ...)  # type: ignore[valid-type]
+            fields[field_name] = (list[field_model], ...)  # type: ignore[valid-type]
         else:
-            field_models[field_name] = (list[field_model], None)  # type: ignore[valid-type]
-    mapping_name = f"{mex_model_class.__name__}Mapping".removeprefix("Extracted")
-    class_model: type[BaseModel] = create_model(mapping_name, **field_models)
-    name = mex_model_class.__name__
-    class_model.__doc__ = str(
-        f"Schema for mapping the properties of the entity type {name}."
+            fields[field_name] = (list[field_model], None)  # type: ignore[valid-type]
+    mapping_name = ensure_postfix(extracted_model.stemType, "Mapping")
+    mapping_model: type[BaseModel] = create_model(mapping_name, **fields)
+    mapping_model.__doc__ = (
+        "Schema for mapping the properties of the entity type "
+        f"{extracted_model.__name__}."
     )
-    return class_model
+    return mapping_model

--- a/mex/common/models/organization.py
+++ b/mex/common/models/organization.py
@@ -3,7 +3,7 @@
 This can be any community or other social, commercial or political structure.
 """
 
-from typing import Annotated, Literal
+from typing import Annotated, ClassVar, Literal
 
 from pydantic import Field
 
@@ -19,7 +19,13 @@ from mex.common.types import (
 )
 
 
-class _OptionalLists(BaseModel):
+class _Stem(BaseModel):
+    stemType: ClassVar[Annotated[Literal["Organization"], Field(frozen=True)]] = (
+        "Organization"
+    )
+
+
+class _OptionalLists(_Stem):
     alternativeName: list[Text] = []
     geprisId: list[
         Annotated[
@@ -84,11 +90,11 @@ class _OptionalLists(BaseModel):
     ] = []
 
 
-class _RequiredLists(BaseModel):
+class _RequiredLists(_Stem):
     officialName: Annotated[list[Text], Field(min_length=1)]
 
 
-class _SparseLists(BaseModel):
+class _SparseLists(_Stem):
     officialName: list[Text] = []
 
 
@@ -131,7 +137,7 @@ class SubtractiveOrganization(_OptionalLists, _SparseLists, SubtractiveRule):
     ] = "SubtractiveOrganization"
 
 
-class PreventiveOrganization(PreventiveRule):
+class PreventiveOrganization(_Stem, PreventiveRule):
     """Rule to prevent primary sources for fields of merged organization items."""
 
     entityType: Annotated[

--- a/mex/common/models/organizational_unit.py
+++ b/mex/common/models/organizational_unit.py
@@ -20,8 +20,8 @@ from mex.common.types import (
 
 
 class _Stem(BaseModel):
-    stemType: ClassVar[Annotated[Literal["OrganizationUnit"], Field(frozen=True)]] = (
-        "OrganizationUnit"
+    stemType: ClassVar[Annotated[Literal["OrganizationalUnit"], Field(frozen=True)]] = (
+        "OrganizationalUnit"
     )
 
 

--- a/mex/common/models/organizational_unit.py
+++ b/mex/common/models/organizational_unit.py
@@ -1,6 +1,6 @@
 """An organizational unit which is part of some larger organization."""
 
-from typing import Annotated, Literal
+from typing import Annotated, ClassVar, Literal
 
 from pydantic import Field
 
@@ -19,7 +19,13 @@ from mex.common.types import (
 )
 
 
-class _OptionalLists(BaseModel):
+class _Stem(BaseModel):
+    stemType: ClassVar[Annotated[Literal["OrganizationUnit"], Field(frozen=True)]] = (
+        "OrganizationUnit"
+    )
+
+
+class _OptionalLists(_Stem):
     alternativeName: list[Text] = []
     email: list[Email] = []
     shortName: list[Text] = []
@@ -27,19 +33,19 @@ class _OptionalLists(BaseModel):
     website: list[Link] = []
 
 
-class _RequiredLists(BaseModel):
+class _RequiredLists(_Stem):
     name: Annotated[list[Text], Field(min_length=1)]
 
 
-class _SparseLists(BaseModel):
+class _SparseLists(_Stem):
     name: list[Text] = []
 
 
-class _OptionalValues(BaseModel):
+class _OptionalValues(_Stem):
     parentUnit: MergedOrganizationalUnitIdentifier | None = None
 
 
-class _VariadicValues(BaseModel):
+class _VariadicValues(_Stem):
     parentUnit: list[MergedOrganizationalUnitIdentifier] = []
 
 
@@ -86,7 +92,7 @@ class SubtractiveOrganizationalUnit(
     ] = "SubtractiveOrganizationalUnit"
 
 
-class PreventiveOrganizationalUnit(PreventiveRule):
+class PreventiveOrganizationalUnit(_Stem, PreventiveRule):
     """Rule to prevent primary sources for fields of merged organizational units."""
 
     entityType: Annotated[

--- a/mex/common/models/person.py
+++ b/mex/common/models/person.py
@@ -1,6 +1,6 @@
 """A person related to a source and/or resource, i.e. a project leader."""
 
-from typing import Annotated, Literal
+from typing import Annotated, ClassVar, Literal
 
 from pydantic import Field
 
@@ -18,7 +18,11 @@ from mex.common.types import (
 )
 
 
-class _OptionalLists(BaseModel):
+class _Stem(BaseModel):
+    stemType: ClassVar[Annotated[Literal["Person"], Field(frozen=True)]] = "Person"
+
+
+class _OptionalLists(_Stem):
     affiliation: list[MergedOrganizationIdentifier] = []
     email: list[Email] = []
     familyName: list[
@@ -107,7 +111,7 @@ class SubtractivePerson(_OptionalLists, SubtractiveRule):
     ] = "SubtractivePerson"
 
 
-class PreventivePerson(PreventiveRule):
+class PreventivePerson(_Stem, PreventiveRule):
     """Rule to prevent primary sources for fields of merged person items."""
 
     entityType: Annotated[

--- a/mex/common/models/primary_source.py
+++ b/mex/common/models/primary_source.py
@@ -1,6 +1,6 @@
 """A collection of information, that is managed and curated by an RKI unit."""
 
-from typing import Annotated, Literal
+from typing import Annotated, ClassVar, Literal
 
 from pydantic import Field
 
@@ -19,7 +19,13 @@ from mex.common.types import (
 )
 
 
-class _OptionalLists(BaseModel):
+class _Stem(BaseModel):
+    stemType: ClassVar[Annotated[Literal["PrimarySource"], Field(frozen=True)]] = (
+        "PrimarySource"
+    )
+
+
+class _OptionalLists(_Stem):
     alternativeTitle: list[Text] = []
     contact: list[
         MergedOrganizationalUnitIdentifier
@@ -33,7 +39,7 @@ class _OptionalLists(BaseModel):
     unitInCharge: list[MergedOrganizationalUnitIdentifier] = []
 
 
-class _OptionalValues(BaseModel):
+class _OptionalValues(_Stem):
     version: (
         Annotated[
             str,
@@ -45,7 +51,7 @@ class _OptionalValues(BaseModel):
     ) = None
 
 
-class _VariadicValues(BaseModel):
+class _VariadicValues(_Stem):
     version: list[
         Annotated[
             str,
@@ -95,7 +101,7 @@ class SubtractivePrimarySource(_OptionalLists, _VariadicValues, SubtractiveRule)
     ] = "SubtractivePrimarySource"
 
 
-class PreventivePrimarySource(PreventiveRule):
+class PreventivePrimarySource(_Stem, PreventiveRule):
     """Rule to prevent primary sources for fields of merged primary source items."""
 
     entityType: Annotated[

--- a/mex/common/models/resource.py
+++ b/mex/common/models/resource.py
@@ -1,6 +1,6 @@
 """A defined piece or collection of information."""
 
-from typing import Annotated, Literal
+from typing import Annotated, ClassVar, Literal
 
 from pydantic import Field
 
@@ -35,7 +35,11 @@ from mex.common.types import (
 from mex.common.types.identifier import MergedPrimarySourceIdentifier
 
 
-class _OptionalLists(BaseModel):
+class _Stem(BaseModel):
+    stemType: ClassVar[Annotated[Literal["Resource"], Field(frozen=True)]] = "Resource"
+
+
+class _OptionalLists(_Stem):
     accessPlatform: list[MergedAccessPlatformIdentifier] = []
     alternativeTitle: list[Text] = []
     anonymizationPseudonymization: list[
@@ -97,7 +101,7 @@ class _OptionalLists(BaseModel):
     ] = []
 
 
-class _RequiredLists(BaseModel):
+class _RequiredLists(_Stem):
     contact: Annotated[
         list[
             MergedOrganizationalUnitIdentifier
@@ -116,7 +120,7 @@ class _RequiredLists(BaseModel):
     ]
 
 
-class _SparseLists(BaseModel):
+class _SparseLists(_Stem):
     contact: list[
         MergedOrganizationalUnitIdentifier
         | MergedPersonIdentifier
@@ -129,7 +133,7 @@ class _SparseLists(BaseModel):
     unitInCharge: list[MergedOrganizationalUnitIdentifier] = []
 
 
-class _OptionalValues(BaseModel):
+class _OptionalValues(_Stem):
     accrualPeriodicity: (
         Annotated[Frequency, Field(examples=["https://mex.rki.de/item/frequency-1"])]
         | None
@@ -160,7 +164,7 @@ class _OptionalValues(BaseModel):
     wasGeneratedBy: MergedActivityIdentifier | None = None
 
 
-class _RequiredValues(BaseModel):
+class _RequiredValues(_Stem):
     accessRestriction: Annotated[
         AccessRestriction,
         Field(
@@ -169,7 +173,7 @@ class _RequiredValues(BaseModel):
     ]
 
 
-class _SparseValues(BaseModel):
+class _SparseValues(_Stem):
     accessRestriction: (
         Annotated[
             AccessRestriction,
@@ -181,7 +185,7 @@ class _SparseValues(BaseModel):
     ) = None
 
 
-class _VariadicValues(BaseModel):
+class _VariadicValues(_Stem):
     accessRestriction: list[
         Annotated[
             AccessRestriction,
@@ -261,7 +265,7 @@ class SubtractiveResource(
     ] = "SubtractiveResource"
 
 
-class PreventiveResource(PreventiveRule):
+class PreventiveResource(_Stem, PreventiveRule):
     """Rule to prevent primary sources for fields of merged resource items."""
 
     entityType: Annotated[

--- a/mex/common/models/rules.py
+++ b/mex/common/models/rules.py
@@ -1,13 +1,13 @@
-from mex.common.models.base import BaseModel
+from mex.common.models.entity import BaseEntity
 
 
-class AdditiveRule(BaseModel):
+class AdditiveRule(BaseEntity):
     """Base rule to add values to merged items."""
 
 
-class SubtractiveRule(BaseModel):
+class SubtractiveRule(BaseEntity):
     """Base rule to subtract values from merged items."""
 
 
-class PreventiveRule(BaseModel):
+class PreventiveRule(BaseEntity):
     """Base rule to prevent primary sources for fields of merged items."""

--- a/mex/common/models/variable.py
+++ b/mex/common/models/variable.py
@@ -1,6 +1,6 @@
 """A single piece of information within a resource."""
 
-from typing import Annotated, Literal
+from typing import Annotated, ClassVar, Literal
 
 from pydantic import Field
 
@@ -19,7 +19,11 @@ from mex.common.types import (
 )
 
 
-class _OptionalLists(BaseModel):
+class _Stem(BaseModel):
+    stemType: ClassVar[Annotated[Literal["Variable"], Field(frozen=True)]] = "Variable"
+
+
+class _OptionalLists(_Stem):
     belongsTo: list[MergedVariableGroupIdentifier] = []
     description: list[Text] = []
     valueSet: list[
@@ -36,7 +40,7 @@ class _OptionalLists(BaseModel):
     ] = []
 
 
-class _RequiredLists(BaseModel):
+class _RequiredLists(_Stem):
     label: Annotated[
         list[
             Annotated[
@@ -53,7 +57,7 @@ class _RequiredLists(BaseModel):
     usedIn: Annotated[list[MergedResourceIdentifier], Field(min_length=1)]
 
 
-class _SparseLists(BaseModel):
+class _SparseLists(_Stem):
     label: list[
         Annotated[
             Text,
@@ -67,7 +71,7 @@ class _SparseLists(BaseModel):
     usedIn: list[MergedResourceIdentifier] = []
 
 
-class _OptionalValues(BaseModel):
+class _OptionalValues(_Stem):
     codingSystem: (
         Annotated[
             str,
@@ -88,7 +92,7 @@ class _OptionalValues(BaseModel):
     ) = None
 
 
-class _VariadicValues(BaseModel):
+class _VariadicValues(_Stem):
     codingSystem: list[
         Annotated[
             str,
@@ -148,7 +152,7 @@ class SubtractiveVariable(
     ] = "SubtractiveVariable"
 
 
-class PreventiveVariable(PreventiveRule):
+class PreventiveVariable(_Stem, PreventiveRule):
     """Rule to prevent primary sources for fields of merged variable items."""
 
     entityType: Annotated[

--- a/mex/common/models/variable_group.py
+++ b/mex/common/models/variable_group.py
@@ -1,6 +1,6 @@
 """The grouping of variables according to a certain aspect."""
 
-from typing import Annotated, Literal
+from typing import Annotated, ClassVar, Literal
 
 from pydantic import Field
 
@@ -17,12 +17,18 @@ from mex.common.types import (
 )
 
 
-class _RequiredLists(BaseModel):
+class _Stem(BaseModel):
+    stemType: ClassVar[Annotated[Literal["VariableGroup"], Field(frozen=True)]] = (
+        "VariableGroup"
+    )
+
+
+class _RequiredLists(_Stem):
     containedBy: Annotated[list[MergedResourceIdentifier], Field(min_length=1)]
     label: Annotated[list[Text], Field(min_length=1)]
 
 
-class _SparseLists(BaseModel):
+class _SparseLists(_Stem):
     containedBy: list[MergedResourceIdentifier] = []
     label: list[Text] = []
 
@@ -66,7 +72,7 @@ class SubtractiveVariableGroup(_SparseLists, SubtractiveRule):
     ] = "SubtractiveVariableGroup"
 
 
-class PreventiveVariableGroup(PreventiveRule):
+class PreventiveVariableGroup(_Stem, PreventiveRule):
     """Rule to prevent primary sources for fields of merged variable group items."""
 
     entityType: Annotated[

--- a/mex/common/transform.py
+++ b/mex/common/transform.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 from enum import Enum
 from functools import cache
 from pathlib import PurePath
-from typing import Any, cast
+from typing import Any
 from uuid import UUID
 
 from pydantic import AnyUrl, SecretStr
@@ -76,17 +76,30 @@ def kebab_to_camel(string: str) -> str:
     return string[:1].upper() + string[1:]
 
 
-def ensure_prefix(string: Any, prefix: Any) -> str:
-    """Return a str with the given prefix prepended if it is not present yet.
+def ensure_prefix(string_like: Any, prefix: Any) -> str:
+    """Return a string with the given prefix prepended if it is not present yet.
 
-    If the string already starts with the prefix, return a copy.
+    If `string_like` already starts with the prefix, return a stringified copy.
     This method is the inverse of `str.removeprefix`.
     """
-    string = str(string)
+    string = str(string_like)
     prefix = str(prefix)
     if string.startswith(prefix):
-        return cast(str, string)
+        return string
     return f"{prefix}{string}"
+
+
+def ensure_postfix(string_like: Any, postfix: Any) -> str:
+    """Return a string with the given postfix appended if it is not present yet.
+
+    If `string_like` already ends with the postfix, return a stringified copy.
+    This method is the inverse of `str.removepostfix`.
+    """
+    string = str(string_like)
+    postfix = str(postfix)
+    if string.endswith(postfix):
+        return string
+    return f"{string}{postfix}"
 
 
 def to_key_and_values(dct: dict[str, Any]) -> Iterable[tuple[str, list[Any]]]:

--- a/mex/common/types/__init__.py
+++ b/mex/common/types/__init__.py
@@ -1,4 +1,4 @@
-from typing import Final, get_args
+from typing import Final, Literal, get_args
 
 from mex.common.types.email import Email
 from mex.common.types.identifier import (
@@ -92,6 +92,7 @@ __all__ = (
     "License",
     "Link",
     "LinkLanguage",
+    "LiteralStringType",
     "MergedAccessPlatformIdentifier",
     "MergedActivityIdentifier",
     "MergedContactPointIdentifier",
@@ -174,3 +175,4 @@ EXTRACTED_IDENTIFIER_CLASSES_BY_NAME: Final[dict[str, type[AnyExtractedIdentifie
 }
 
 AnyPrimitiveType = str | int | float | None | bool
+LiteralStringType = type(Literal["str"])

--- a/mex/common/types/__init__.py
+++ b/mex/common/types/__init__.py
@@ -106,24 +106,25 @@ __all__ = (
     "NESTED_MODEL_CLASSES_BY_NAME",
     "NESTED_MODEL_CLASSES",
     "PathWrapper",
+    "PrimitiveTypes",
     "ResourceTypeGeneral",
     "Sink",
     "split_to_caps",
     "TechnicalAccessibility",
-    "Text",
-    "TextLanguage",
-    "Theme",
     "TEMPORAL_ENTITY_CLASSES_BY_PRECISION",
     "TEMPORAL_ENTITY_FORMATS_BY_PRECISION",
     "TemporalEntity",
-    "YearMonth",
-    "YearMonthDay",
-    "YearMonthDayTime",
     "TemporalEntityPrecision",
+    "Text",
+    "TextLanguage",
+    "Theme",
     "UTC",
     "VocabularyEnum",
     "VocabularyLoader",
     "WorkPath",
+    "YearMonth",
+    "YearMonthDay",
+    "YearMonthDayTime",
 )
 
 AnyNestedModel = Link | Text
@@ -171,3 +172,5 @@ EXTRACTED_IDENTIFIER_CLASSES: Final[list[type[AnyExtractedIdentifier]]] = list(
 EXTRACTED_IDENTIFIER_CLASSES_BY_NAME: Final[dict[str, type[AnyExtractedIdentifier]]] = {
     cls.__name__: cls for cls in EXTRACTED_IDENTIFIER_CLASSES
 }
+
+PrimitiveTypes = str | int | float | None | bool

--- a/mex/common/types/__init__.py
+++ b/mex/common/types/__init__.py
@@ -67,6 +67,7 @@ __all__ = (
     "AnonymizationPseudonymization",
     "AnyMergedIdentifier",
     "AnyNestedModel",
+    "AnyPrimitiveType",
     "APIType",
     "AssetsPath",
     "CET",
@@ -106,7 +107,6 @@ __all__ = (
     "NESTED_MODEL_CLASSES_BY_NAME",
     "NESTED_MODEL_CLASSES",
     "PathWrapper",
-    "PrimitiveTypes",
     "ResourceTypeGeneral",
     "Sink",
     "split_to_caps",
@@ -173,4 +173,4 @@ EXTRACTED_IDENTIFIER_CLASSES_BY_NAME: Final[dict[str, type[AnyExtractedIdentifie
     cls.__name__: cls for cls in EXTRACTED_IDENTIFIER_CLASSES
 }
 
-PrimitiveTypes = str | int | float | None | bool
+AnyPrimitiveType = str | int | float | None | bool

--- a/tests/models/test_filter.py
+++ b/tests/models/test_filter.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, ClassVar, Literal
 
 from pydantic import Field
 
@@ -10,7 +10,11 @@ from mex.common.types import MergedOrganizationalUnitIdentifier
 from mex.common.types.email import Email
 
 
-class DummyClass(ExtractedData):
+class ExtractedDummy(ExtractedData):
+    stemType: ClassVar[Annotated[Literal["Dummy"], Field(frozen=True)]] = "Dummy"
+    entityType: Annotated[
+        Literal["ExtractedDummy"], Field(alias="$type", frozen=True)
+    ] = "ExtractedDummy"
     dummy_identifier: MergedOrganizationalUnitIdentifier | None = None  # not required
     dummy_str: str
     dummy_int: int | None = None  # not required
@@ -20,7 +24,7 @@ class DummyClass(ExtractedData):
 
 
 def test_entity_filter_schema() -> None:
-    schema_model = generate_entity_filter_schema(DummyClass)
+    schema_model = generate_entity_filter_schema(ExtractedDummy)
 
     expected = {
         "$defs": {
@@ -83,15 +87,16 @@ def test_entity_filter_schema() -> None:
                 "type": "object",
             },
         },
+        "description": "Schema for entity filters for the entity type ExtractedDummy.",
         "properties": {
-            "DummyClass": {
+            "ExtractedDummy": {
                 "default": None,
                 "items": {"$ref": "#/$defs/EntityFilter"},
-                "title": "Dummyclass",
+                "title": "Extracteddummy",
                 "type": "array",
             }
         },
-        "title": "DummyClass",
+        "title": "DummyEntityFilter",
         "type": "object",
     }
 

--- a/tests/models/test_mapping.py
+++ b/tests/models/test_mapping.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Literal
+from typing import Annotated, ClassVar, Literal
 
 from pydantic import Field
 
@@ -17,10 +17,11 @@ class MergedDummyIdentifier(Identifier):
     pass
 
 
-class ExtractedDummyClass(ExtractedData):
+class ExtractedDummy(ExtractedData):
+    stemType: ClassVar[Annotated[Literal["Dummy"], Field(frozen=True)]] = "Dummy"
     entityType: Annotated[
-        Literal["ExtractedDummyClass"], Field(alias="$type", frozen=True)
-    ] = "ExtractedDummyClass"
+        Literal["ExtractedDummy"], Field(alias="$type", frozen=True)
+    ] = "ExtractedDummy"
     identifier: Annotated[ExtractedDummyIdentifier, Field(frozen=True)]
     stableTargetId: MergedDummyIdentifier
     dummy_unit: MergedOrganizationalUnitIdentifier | None = None  # not required
@@ -32,7 +33,7 @@ class ExtractedDummyClass(ExtractedData):
 
 
 def test_generate_mapping_schema() -> None:
-    schema_model = generate_mapping_schema(ExtractedDummyClass)
+    schema_model = generate_mapping_schema(ExtractedDummy)
 
     expected = {
         "$defs": {
@@ -746,7 +747,7 @@ def test_generate_mapping_schema() -> None:
                 "type": "object",
             },
         },
-        "description": "Schema for mapping the properties of the entity type ExtractedDummyClass.",
+        "description": "Schema for mapping the properties of the entity type ExtractedDummy.",
         "properties": {
             "hadPrimarySource": {
                 "items": {"$ref": "#/$defs/HadprimarysourceFieldsInPrimarySource"},
@@ -813,7 +814,7 @@ def test_generate_mapping_schema() -> None:
             "dummy_email",
             "dummy_min_length_list",
         ],
-        "title": "DummyClassMapping",
+        "title": "DummyMapping",
         "type": "object",
     }
 

--- a/tests/models/test_mapping.py
+++ b/tests/models/test_mapping.py
@@ -4,7 +4,7 @@ from pydantic import Field
 
 from mex.common.models import ExtractedData
 from mex.common.models.mapping import (
-    generate_mapping_schema_for_mex_class,
+    generate_mapping_schema,
 )
 from mex.common.types import Email, Identifier, MergedOrganizationalUnitIdentifier
 
@@ -32,7 +32,7 @@ class ExtractedDummyClass(ExtractedData):
 
 
 def test_generate_mapping_schema() -> None:
-    schema_model = generate_mapping_schema_for_mex_class(ExtractedDummyClass)
+    schema_model = generate_mapping_schema(ExtractedDummyClass)
 
     expected = {
         "$defs": {

--- a/tests/models/test_model_schemas.py
+++ b/tests/models/test_model_schemas.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import pytest
 
-from mex.common.models import EXTRACTED_MODEL_CLASSES_BY_NAME
+from mex.common.models import EXTRACTED_MODEL_CLASSES
 from mex.common.transform import dromedary_to_kebab
 from mex.common.types.identifier import MEX_ID_PATTERN
 
@@ -17,10 +17,10 @@ MEX_MODEL_ENTITIES = files("mex.model.entities")
 GENERATED_SCHEMAS = dict(
     sorted(
         {
-            name.removeprefix("Extracted"): model.model_json_schema(
+            model.stemType: model.model_json_schema(
                 ref_template="/schema/fields/{model}"
             )
-            for name, model in EXTRACTED_MODEL_CLASSES_BY_NAME.items()
+            for model in EXTRACTED_MODEL_CLASSES
         }.items()
     )
 )

--- a/tests/models/test_rules.py
+++ b/tests/models/test_rules.py
@@ -1,5 +1,4 @@
 from mex.common.models import BASE_MODEL_CLASSES_BY_NAME, PREVENTIVE_MODEL_CLASSES
-from mex.common.transform import ensure_prefix
 from mex.common.types import MergedPrimarySourceIdentifier
 
 

--- a/tests/models/test_rules.py
+++ b/tests/models/test_rules.py
@@ -5,7 +5,7 @@ from mex.common.types import MergedPrimarySourceIdentifier
 
 def test_preventive_models_define_same_fields_as_base_model() -> None:
     for preventive_rule in PREVENTIVE_MODEL_CLASSES:
-        base_model_name = ensure_prefix(preventive_rule.stemType, "Base")
+        base_model_name = "Base" + preventive_rule.stemType
         base_model = BASE_MODEL_CLASSES_BY_NAME[base_model_name]
         expected_fields = {"entityType", *base_model.model_fields}
         assert set(preventive_rule.model_fields) == expected_fields

--- a/tests/models/test_rules.py
+++ b/tests/models/test_rules.py
@@ -1,10 +1,11 @@
 from mex.common.models import BASE_MODEL_CLASSES_BY_NAME, PREVENTIVE_MODEL_CLASSES
+from mex.common.transform import ensure_prefix
 from mex.common.types import MergedPrimarySourceIdentifier
 
 
 def test_preventive_models_define_same_fields_as_base_model() -> None:
     for preventive_rule in PREVENTIVE_MODEL_CLASSES:
-        base_model_name = preventive_rule.__name__.replace("Preventive", "Base")
+        base_model_name = ensure_prefix(preventive_rule.stemType, "Base")
         base_model = BASE_MODEL_CLASSES_BY_NAME[base_model_name]
         expected_fields = {"entityType", *base_model.model_fields}
         assert set(preventive_rule.model_fields) == expected_fields

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -13,6 +13,7 @@ from mex.common.transform import (
     MExEncoder,
     dromedary_to_kebab,
     dromedary_to_snake,
+    ensure_postfix,
     ensure_prefix,
     kebab_to_camel,
     snake_to_dromedary,
@@ -173,6 +174,26 @@ def test_kebab_to_camel(string: str, expected: str) -> None:
 )
 def test_ensure_prefix(string: Any, prefix: Any, expected: str) -> None:
     result = ensure_prefix(string, prefix)
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("string", "postfix", "expected"),
+    [
+        ("", "", ""),
+        ("banana", "na", "banana"),
+        ("foo", "bar", "foobar"),
+        (
+            UUID("{12345678-1234-5678-1234-567812345678}"),
+            -42,
+            "12345678-1234-5678-1234-567812345678-42",
+        ),
+    ],
+    ids=["empty", "already-postfixed", "postfix-added", "stringified"],
+)
+def test_ensure_postfix(string: Any, postfix: Any, expected: str) -> None:
+    result = ensure_postfix(string, postfix)
 
     assert result == expected
 


### PR DESCRIPTION
# PR Context
- more prep work for https://github.com/robert-koch-institut/mex-backend/pull/45

# Added

- add static class attribute `stemType` to models, containing an unprefixed entityType
- add `AnyRuleModel`, `RULE_MODEL_CLASSES`, `RULE_MODEL_CLASSES_BY_NAME` to models
- add type aliases `AnyPrimitiveType` and `LiteralStringType` to types
- add new utility function `ensure_postfix` for adding postfixes to strings

# Changes

- clean-up and unify `mapping` and `filter` class generation
