### PR TITLE
Bump cookiecutter template to cbe768

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "checkout": null,
-  "commit": "ca268e621fef9b461c8ab1a6cc08b7a76ee31af3",
+  "commit": "cbe768db4294a009584c80ab039adca78207b746",
   "context": {
     "cookiecutter": {
       "project_name": "common",


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/cbe768
