### PR TITLE
Bump cookiecutter template to 39db8b

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "checkout": null,
-  "commit": "71137ce60c22f449d66138dcd113772acd678a39",
+  "commit": "39db8b85e6bbde62ab72318329d9410f14187dab",
   "context": {
     "cookiecutter": {
       "project_name": "common",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.8
+    rev: v0.4.9
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ distribution = true
 [tool.pdm.scripts]
 update-all = { cmd = "pdm update --group :all --update-all --save-compatible" }
 lock-all = { cmd = "pdm lock --group :all --refresh" }
-install-all = { cmd = "pdm install --group :all --no-editable --no-lock" }
+install-all = { cmd = "pdm install --group :all --frozen-lockfile" }
 export-all = { cmd = "pdm export --group :all --no-hashes -f requirements" }
 apidoc = { cmd = "pdm run sphinx-apidoc -f -o docs/source mex" }
 sphinx = { cmd = "pdm run sphinx-build -aE -b dirhtml docs docs/dist" }


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/39db8b

# Conflicts

```diff a/pyproject.toml b/pyproject.toml	(rejected hunks)
@@ -16,7 +16,7 @@ optional-dependencies.dev = [
     "pytest-random-order==1.1.1",
     "pytest-xdist==3.6.1",
     "pytest==8.2.2",
-    "ruff==0.4.8",
+    "ruff==0.4.9",
     "sphinx==7.3.7",
 ]
 
```
