### PR TITLE
feature/fix listyness for computed fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- add missing listyness-fix support for computed-fields
+
 ### Security
 
 ## [0.30.0] - 2024-07-16

--- a/mex/common/models/__init__.py
+++ b/mex/common/models/__init__.py
@@ -79,7 +79,7 @@ from mex.common.models.activity import (
     PreventiveActivity,
     SubtractiveActivity,
 )
-from mex.common.models.base import BaseModel
+from mex.common.models.base import BaseModel, GenericFieldInfo
 from mex.common.models.contact_point import (
     AdditiveContactPoint,
     BaseContactPoint,
@@ -211,6 +211,7 @@ __all__ = (
     "MergedOrganization",
     "MergedOrganizationalUnit",
     "MergedPerson",
+    "GenericFieldInfo",
     "MergedPrimarySource",
     "MergedResource",
     "MergedVariable",

--- a/mex/common/models/base.py
+++ b/mex/common/models/base.py
@@ -1,13 +1,12 @@
 import hashlib
 import json
 from collections.abc import MutableMapping
+from dataclasses import dataclass
 from functools import cache
 from types import UnionType
 from typing import Any, Union
 
-from pydantic import (
-    BaseModel as PydanticBaseModel,
-)
+from pydantic import BaseModel as PydanticBaseModel
 from pydantic import (
     ConfigDict,
     TypeAdapter,
@@ -23,6 +22,15 @@ from mex.common.transform import MExEncoder
 from mex.common.utils import get_inner_types
 
 
+@dataclass
+class GenericFieldInfo:
+    """Abstraction class for unifying `FieldInfo` and `ComputedFieldInfo` objects."""
+
+    alias: str | None
+    annotation: type[Any] | None
+    frozen: bool
+
+
 class BaseModel(PydanticBaseModel):
     """Common base class for all MEx model classes."""
 
@@ -36,6 +44,29 @@ class BaseModel(PydanticBaseModel):
         validate_default=True,
         validate_assignment=True,
     )
+
+    @classmethod
+    @cache
+    def get_all_fields(cls) -> dict[str, GenericFieldInfo]:
+        """Return a combined dict of defined and computed fields."""
+        return {
+            **{
+                name: GenericFieldInfo(
+                    alias=info.alias,
+                    annotation=info.annotation,
+                    frozen=bool(info.frozen),
+                )
+                for name, info in cls.model_fields.items()
+            },
+            **{
+                name: GenericFieldInfo(
+                    alias=info.alias,
+                    annotation=info.return_type,
+                    frozen=True,
+                )
+                for name, info in cls.model_computed_fields.items()
+            },
+        }
 
     @classmethod
     def model_json_schema(
@@ -69,7 +100,7 @@ class BaseModel(PydanticBaseModel):
         """Build a cached mapping from field alias to field names."""
         return {
             field_info.alias or field_name: field_name
-            for field_name, field_info in cls.model_fields.items()
+            for field_name, field_info in cls.get_all_fields().items()
         }
 
     @classmethod
@@ -77,7 +108,7 @@ class BaseModel(PydanticBaseModel):
     def _get_list_field_names(cls) -> list[str]:
         """Build a cached list of fields that look like lists."""
         field_names = []
-        for field_name, field_info in cls.model_fields.items():
+        for field_name, field_info in cls.get_all_fields().items():
             field_types = get_inner_types(
                 field_info.annotation, unpack=(Union, UnionType)
             )
@@ -93,7 +124,7 @@ class BaseModel(PydanticBaseModel):
     def _get_field_names_allowing_none(cls) -> list[str]:
         """Build a cached list of fields can be set to None."""
         field_names: list[str] = []
-        for field_name, field_info in cls.model_fields.items():
+        for field_name, field_info in cls.get_all_fields().items():
             validator = TypeAdapter(field_info.annotation)
             try:
                 validator.validate_python(None)
@@ -138,35 +169,8 @@ class BaseModel(PydanticBaseModel):
         # already desired shape
         return value
 
-    @model_validator(mode="before")
-    @classmethod
-    def fix_listyness(cls, data: Any) -> Any:
-        """Adjust the listyness of to-be-parsed data to match the desired shape.
-
-        If that data is a Mapping and the model defines a list[T] field but the raw data
-        contains just a value of type T, it will be wrapped into a list. If the raw
-        data contains a literal `None`, but the list field is defined as required, we
-        substitute an empty list.
-
-        If the model does not expect a list, but the raw data contains a list with
-        no entries, it will be substituted with `None`. If the raw data contains exactly
-        one entry, then it will be unpacked from the list. If it contains more than one
-        entry however, an error is raised, because we would not know which to choose.
-
-        Args:
-            data: Raw data or instance to be parsed
-
-        Returns:
-            data with fixed list shapes
-        """
-        if isinstance(data, MutableMapping):
-            for name, value in data.items():
-                field_name = cls._get_alias_lookup().get(name, name)
-                if field_name in cls.model_fields:
-                    data[name] = cls._fix_value_listyness_for_field(field_name, value)
-        return data
-
     @model_validator(mode="wrap")
+    @classmethod
     def verify_computed_field_consistency(
         cls, data: Any, handler: ValidatorFunctionWrapHandler
     ) -> Any:
@@ -208,6 +212,38 @@ class BaseModel(PydanticBaseModel):
         if computed_values != custom_values:
             raise ValueError("Cannot set computed fields to custom values!")
         return result
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def fix_listyness(cls, data: Any, handler: ValidatorFunctionWrapHandler) -> Any:
+        """Adjust the listyness of to-be-parsed data to match the desired shape.
+
+        If that data is a Mapping and the model defines a list[T] field but the raw data
+        contains just a value of type T, it will be wrapped into a list. If the raw
+        data contains a literal `None`, but the list field is defined as required, we
+        substitute an empty list.
+
+        If the model does not expect a list, but the raw data contains a list with
+        no entries, it will be substituted with `None`. If the raw data contains exactly
+        one entry, then it will be unpacked from the list. If it contains more than one
+        entry however, an error is raised, because we would not know which to choose.
+
+        Args:
+            data: Raw data or instance to be parsed
+            handler: Validator function wrap handler
+
+        Returns:
+            data with fixed list shapes
+        """
+        # XXX This needs to be a "wrap" validator that is defined *after* the computed
+        #     field model validator, so it runs *before* the computed field validator.
+        #     Sigh, see https://github.com/pydantic/pydantic/discussions/7434
+        if isinstance(data, MutableMapping):
+            for name, value in data.items():
+                field_name = cls._get_alias_lookup().get(name, name)
+                if field_name in cls.get_all_fields():
+                    data[name] = cls._fix_value_listyness_for_field(field_name, value)
+        return handler(data)
 
     def checksum(self) -> str:
         """Calculate md5 checksum for this model."""

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -4,7 +4,7 @@ from typing import Any
 import pytest
 from pydantic import ValidationError, computed_field
 
-from mex.common.models import BaseModel
+from mex.common.models import BaseModel, GenericFieldInfo
 
 
 class ComplexDummyModel(BaseModel):
@@ -15,18 +15,33 @@ class ComplexDummyModel(BaseModel):
     optional_list: list[str] | None = None
     required_list: list[str] = []
 
+    @computed_field(alias="computedInt")  # type: ignore[misc]
+    @property
+    def computed_int(self) -> int:
+        return 42
 
-def test_get_field_names_allowing_none() -> None:
-    assert ComplexDummyModel._get_field_names_allowing_none() == [
-        "optional_str",
-        "optional_list",
-    ]
+
+def test_get_alias_lookup() -> None:
+    assert ComplexDummyModel._get_alias_lookup() == {
+        "optional_str": "optional_str",
+        "required_str": "required_str",
+        "optional_list": "optional_list",
+        "required_list": "required_list",
+        "computedInt": "computed_int",
+    }
 
 
 def test_get_list_field_names() -> None:
     assert ComplexDummyModel._get_list_field_names() == [
         "optional_list",
         "required_list",
+    ]
+
+
+def test_get_field_names_allowing_none() -> None:
+    assert ComplexDummyModel._get_field_names_allowing_none() == [
+        "optional_str",
+        "optional_list",
     ]
 
 
@@ -62,6 +77,28 @@ class Animal(Enum):
         ({"optional_list": "value"}, {"optional_list": ["value"]}),
         ({"required_list": None}, {"required_list": []}),
         ({"required_list": "value"}, {"required_list": ["value"]}),
+        ({"computed_int": 42}, {"computed_int": 42}),
+        ({"computed_int": [42]}, {"computed_int": 42}),
+        (
+            {"computed_int": 9999999},
+            "Cannot set computed fields to custom values! [type=value_error, "
+            "input_value={}, input_type=dict]",
+        ),
+    ],
+    ids=[
+        "empty list as optional single",
+        "None in list as optional single",
+        "string in list as optional single",
+        "empty list as required single",
+        "None in list as required single",
+        "strings in list as required single",
+        "None as optional list",
+        "string as optional list",
+        "None as required list",
+        "string as required list",
+        "correct int as computed single",
+        "correct int in list as computed single",
+        "false int as computed single",
     ],
 )
 def test_base_model_listyness_fix(
@@ -72,7 +109,9 @@ def test_base_model_listyness_fix(
     except Exception as error:
         assert str(expected) in str(error)
     else:
-        assert model.model_dump(exclude_unset=True) == expected
+        actual = model.model_dump()
+        for key, value in expected.items():
+            assert actual[key] == value
 
 
 def test_base_model_listyness_fix_only_runs_on_mutable_mapping() -> None:
@@ -129,6 +168,13 @@ def test_field_assignment_on_model_with_computed_field() -> None:
 
     # non-computed field works as expected
     computer.ram = 32
+
+
+def test_get_all_fields_on_model_with_computed_field() -> None:
+    assert Computer.get_all_fields() == {
+        "cpus": GenericFieldInfo(alias=None, annotation=int, frozen=True),
+        "ram": GenericFieldInfo(alias=None, annotation=int, frozen=False),
+    }
 
 
 class DummyBaseModel(BaseModel):


### PR DESCRIPTION
# PR Context
This unblocks the upgrade of mex-backend's mex-common dependency past 0.29.0.

It allows the follow snipped to run without errors:

```python
class Computer(BaseModel):
    @computed_field
    def cpus(self) -> int:
        return 4

c = Computer.model_validate({"cpus": [4]})
```

This is needed by the backend because all relationship fields (which includes the computed stableTargetId field) are collected as lists of ids from the graph. And a model could not be validated after fetching, if the _listyness_ was not corrected-for.

# Fixed

- add missing listyness-fix support for computed-fields
