### PR TITLE
feature/mx-1658 fix wikidata 403 bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
-- wikidata search organization request query update with optional language parameter
+- update wikidata search organization request query, with optional language parameter
   wikidata query search can be enhanced by specifying the language.
   EN is the default language.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 - wikidata search organization request query update with optional language parameter
+  wikidata query search can be enhanced by specifying the language.
+  EN is the default language.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- HTTP connector backoff for 10 retries on 403 from server
+- `rki/mex` user agent is sent with query requests via wikidata connector
+
 ### Changes
+
+- wikidata search organization request query update with optional language parameter
 
 ### Deprecated
 
@@ -36,8 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.31.0] - 2024-07-17
 
 ### Removed
+
 - BREAKING: ability to store different settings instances at the same time. Dependent
-    repositories now must bundle all settings in a single class.
+  repositories now must bundle all settings in a single class.
 
 ## [0.30.0] - 2024-07-16
 

--- a/mex/common/connector/http.py
+++ b/mex/common/connector/http.py
@@ -74,9 +74,8 @@ class HTTPConnector(BaseConnector):
         else:
             url = self.url
         kwargs.setdefault("timeout", self.TIMEOUT)
-        kwargs.setdefault(
-            "headers", {"User-Agent": "rki/mex", "Api-User-Agent": "rki/mex"}
-        )
+        if not kwargs.get("headers"):
+            kwargs.setdefault("headers", {})
         kwargs["headers"].setdefault("Accept", "application/json")
 
         if payload:

--- a/mex/common/connector/http.py
+++ b/mex/common/connector/http.py
@@ -74,7 +74,9 @@ class HTTPConnector(BaseConnector):
         else:
             url = self.url
         kwargs.setdefault("timeout", self.TIMEOUT)
-        kwargs.setdefault("headers", {})
+        kwargs.setdefault(
+            "headers", {"User-Agent": "rki/mex", "Api-User-Agent": "rki/mex"}
+        )
         kwargs["headers"].setdefault("Accept", "application/json")
 
         if payload:
@@ -104,6 +106,11 @@ class HTTPConnector(BaseConnector):
     @backoff.on_predicate(
         backoff.fibo,
         lambda response: cast(Response, response).status_code == 429,
+        max_tries=10,
+    )
+    @backoff.on_predicate(
+        backoff.fibo,
+        lambda response: cast(Response, response).status_code == 403,
         max_tries=10,
     )
     @backoff.on_exception(backoff.fibo, RequestException, max_tries=6)

--- a/mex/common/settings.py
+++ b/mex/common/settings.py
@@ -180,6 +180,12 @@ class BaseSettings(PydanticBaseSettings):
         "organization ID",
         validation_alias="MEX_WIKI_QUERY_SERVICE_URL",
     )
+    mex_web_user_agent: str = Field(
+        "rki/mex",
+        description="a user agent is sent in the header of some requests to external "
+        "services ",
+        validation_alias="MEX_WEB_USER_AGENT",
+    )
 
     def text(self) -> str:
         """Dump the current settings into a readable table."""

--- a/mex/common/wikidata/connector.py
+++ b/mex/common/wikidata/connector.py
@@ -29,8 +29,9 @@ class WikidataQueryServiceConnector(HTTPConnector):
             list: list of all items found
         """
         params = {"format": "json", "query": query}
+        headers = {"User-Agent": "rki/mex", "Api-User-Agent": "rki/mex"}
 
-        results = self.request("GET", params=params)
+        results = self.request("GET", params=params, headers=headers)
 
         return results["results"]["bindings"]  # type: ignore
 
@@ -77,6 +78,7 @@ class WikidataAPIConnector(HTTPConnector):
             ),
             "formatversion": "2",
         }
+        headers = {"User-Agent": "rki/mex", "Api-User-Agent": "rki/mex"}
 
-        results = self.request("GET", params=params)
+        results = self.request("GET", params=params, headers=headers)
         return results["entities"][item_id]  # type: ignore

--- a/mex/common/wikidata/connector.py
+++ b/mex/common/wikidata/connector.py
@@ -28,8 +28,12 @@ class WikidataQueryServiceConnector(HTTPConnector):
         Returns:
             list: list of all items found
         """
+        settings = BaseSettings.get()
         params = {"format": "json", "query": query}
-        headers = {"User-Agent": "rki/mex", "Api-User-Agent": "rki/mex"}
+        headers = {
+            "User-Agent": f"{settings.mex_web_user_agent}",
+            "Api-User-Agent": f"{settings.mex_web_user_agent}",
+        }
 
         results = self.request("GET", params=params, headers=headers)
 
@@ -60,6 +64,7 @@ class WikidataAPIConnector(HTTPConnector):
         Returns:
             dict[str, Any]: details of the found item.
         """
+        settings = BaseSettings.get()
         params = {
             "action": "wbgetentities",
             "format": "json",
@@ -78,7 +83,9 @@ class WikidataAPIConnector(HTTPConnector):
             ),
             "formatversion": "2",
         }
-        headers = {"User-Agent": "rki/mex", "Api-User-Agent": "rki/mex"}
-
+        headers = {
+            "User-Agent": f"{settings.mex_web_user_agent}",
+            "Api-User-Agent": f"{settings.mex_web_user_agent}",
+        }
         results = self.request("GET", params=params, headers=headers)
         return results["entities"][item_id]  # type: ignore

--- a/mex/common/wikidata/extract.py
+++ b/mex/common/wikidata/extract.py
@@ -13,15 +13,15 @@ def search_organization_by_label(
     item_label: str,
     lang: TextLanguage = TextLanguage.EN,
 ) -> WikidataOrganization | None:
-    """Search for an item in wikidata. Only organizations are fetched.
+    """Search for an item in wikidata. Only organizations are searched.
 
     Args:
         item_label: Item title or label to be searched
         lang: lang in which item should be searched. Default: TextLanguage.EN
 
     Returns:
-        WikidataOrganization if only one organization is found
-        None if no or multiple organizations are found
+        WikidataOrganization if organization is found
+        None if no organization is found
     """
     connector = WikidataQueryServiceConnector.get()
     item_label = item_label.replace('"', "")

--- a/mex/common/wikidata/extract.py
+++ b/mex/common/wikidata/extract.py
@@ -25,7 +25,7 @@ def search_organization_by_label(
     """
     connector = WikidataQueryServiceConnector.get()
     item_label = item_label.replace('"', "")
-    query_string_new = (
+    query_string = (
         "SELECT distinct ?item ?itemLabel ?itemDescription "
         "WHERE { "
         "SERVICE wikibase:mwapi { "
@@ -43,7 +43,7 @@ def search_organization_by_label(
         "LIMIT 1 "
     )
 
-    results = connector.get_data_by_query(query_string_new)
+    results = connector.get_data_by_query(query_string)
 
     if not results:
         return None
@@ -71,7 +71,7 @@ def get_count_of_found_organizations_by_label(
     """
     connector = WikidataQueryServiceConnector.get()
     item_label = item_label.replace('"', "")
-    query_string_new = (
+    query_string = (
         "SELECT (COUNT(distinct ?item) AS ?count) "
         "WHERE { "
         "SERVICE wikibase:mwapi { "
@@ -88,7 +88,7 @@ def get_count_of_found_organizations_by_label(
         "ORDER BY ASC(?num) "
     )
 
-    result = connector.get_data_by_query(query_string_new)
+    result = connector.get_data_by_query(query_string)
     return int(result[0]["count"]["value"])
 
 
@@ -111,7 +111,7 @@ def search_organizations_by_label(
     """
     connector = WikidataQueryServiceConnector.get()
     item_label = item_label.replace('"', "")
-    query_string_new = (
+    query_string = (
         "SELECT distinct ?item ?itemLabel ?itemDescription "
         "WHERE { "
         "SERVICE wikibase:mwapi { "
@@ -130,7 +130,7 @@ def search_organizations_by_label(
         f"LIMIT {limit} "
     )
 
-    results = connector.get_data_by_query(query_string_new)
+    results = connector.get_data_by_query(query_string)
     for item in results:
         try:
             wd_item_id = item["item"]["value"].split("/")[-1]

--- a/tests/wikidata/test_extract.py
+++ b/tests/wikidata/test_extract.py
@@ -63,7 +63,9 @@ def test_get_count_of_found_organizations_by_label() -> None:
 @pytest.mark.integration
 def test_search_organization_by_label_for_none() -> None:
     """Test if None is returned when multiple organizations are found."""
-    search_result = search_organization_by_label(item_label="BMW")
+    search_result = search_organization_by_label(
+        item_label="Blah-test128%3h2 .1 12 bus"
+    )
     assert search_result is None
 
 
@@ -229,22 +231,10 @@ def test_search_organization_by_label_mocked(monkeypatch: MonkeyPatch) -> None:
     "mocked_session_wikidata_query_service", "mocked_session_wikidata_api"
 )
 def test_search_organization_by_label_for_none_mocked(monkeypatch: MonkeyPatch) -> None:
-    expected_query_response = [
-        {
-            "item": {"type": "uri", "value": "http://www.wikidata.org/entity/Q26678"},
-        },
-        {
-            "item": {"type": "uri", "value": "http://www.wikidata.org/entity/Q821937"},
-        },
-    ]
-
-    def mocked_query_response() -> list[dict[str, dict[str, str]]]:
-        return expected_query_response
-
     monkeypatch.setattr(
         WikidataQueryServiceConnector,
         "get_data_by_query",
-        lambda self, _: mocked_query_response(),
+        lambda self, _: [],
     )
 
     def mocked_item_details_response() -> Any:


### PR DESCRIPTION
### Added

- HTTP connector backoff for 10 retries on 403 from server
- `rki/mex` user agent is sent with query requests via wikidata connector

### Changes

- update wikidata search organization request query, with optional language parameter
  wikidata query search can be enhanced by specifying the language.
  EN is the default language.
