### PR TITLE
feature/mx-1406 add rule set models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - convenience function `get_merged_organization_id_by_query_with_extract_transform_and_load`
   for getting the stableTargetId of an organization, while transforming and loading the
   organization using the provided load function
+- models for rule sets along with typing and lookups
 
 ### Changes
 

--- a/mex/common/models/__init__.py
+++ b/mex/common/models/__init__.py
@@ -64,6 +64,7 @@ lists of models, lookups by class name and typing for unions of models.
 from typing import Final, get_args
 
 from mex.common.models.access_platform import (
+    AccessPlatformRuleSet,
     AdditiveAccessPlatform,
     BaseAccessPlatform,
     ExtractedAccessPlatform,
@@ -72,6 +73,7 @@ from mex.common.models.access_platform import (
     SubtractiveAccessPlatform,
 )
 from mex.common.models.activity import (
+    ActivityRuleSet,
     AdditiveActivity,
     BaseActivity,
     ExtractedActivity,
@@ -83,6 +85,7 @@ from mex.common.models.base import BaseModel, GenericFieldInfo
 from mex.common.models.contact_point import (
     AdditiveContactPoint,
     BaseContactPoint,
+    ContactPointRuleSet,
     ExtractedContactPoint,
     MergedContactPoint,
     PreventiveContactPoint,
@@ -91,6 +94,7 @@ from mex.common.models.contact_point import (
 from mex.common.models.distribution import (
     AdditiveDistribution,
     BaseDistribution,
+    DistributionRuleSet,
     ExtractedDistribution,
     MergedDistribution,
     PreventiveDistribution,
@@ -110,6 +114,7 @@ from mex.common.models.organization import (
     BaseOrganization,
     ExtractedOrganization,
     MergedOrganization,
+    OrganizationRuleSet,
     PreventiveOrganization,
     SubtractiveOrganization,
 )
@@ -118,6 +123,7 @@ from mex.common.models.organizational_unit import (
     BaseOrganizationalUnit,
     ExtractedOrganizationalUnit,
     MergedOrganizationalUnit,
+    OrganizationalUnitRuleSet,
     PreventiveOrganizationalUnit,
     SubtractiveOrganizationalUnit,
 )
@@ -126,6 +132,7 @@ from mex.common.models.person import (
     BasePerson,
     ExtractedPerson,
     MergedPerson,
+    PersonRuleSet,
     PreventivePerson,
     SubtractivePerson,
 )
@@ -135,6 +142,7 @@ from mex.common.models.primary_source import (
     ExtractedPrimarySource,
     MergedPrimarySource,
     PreventivePrimarySource,
+    PrimarySourceRuleSet,
     SubtractivePrimarySource,
 )
 from mex.common.models.resource import (
@@ -143,6 +151,7 @@ from mex.common.models.resource import (
     ExtractedResource,
     MergedResource,
     PreventiveResource,
+    ResourceRuleSet,
     SubtractiveResource,
 )
 from mex.common.models.rules import AdditiveRule, PreventiveRule, SubtractiveRule
@@ -153,6 +162,7 @@ from mex.common.models.variable import (
     MergedVariable,
     PreventiveVariable,
     SubtractiveVariable,
+    VariableRuleSet,
 )
 from mex.common.models.variable_group import (
     AdditiveVariableGroup,
@@ -161,6 +171,7 @@ from mex.common.models.variable_group import (
     MergedVariableGroup,
     PreventiveVariableGroup,
     SubtractiveVariableGroup,
+    VariableGroupRuleSet,
 )
 
 __all__ = (
@@ -369,6 +380,26 @@ AnyRuleModel = AnyAdditiveModel | AnySubtractiveModel | AnyPreventiveModel
 RULE_MODEL_CLASSES: Final[list[type[AnyRuleModel]]] = list(get_args(AnyRuleModel))
 RULE_MODEL_CLASSES_BY_NAME: Final[dict[str, type[AnyRuleModel]]] = {
     cls.__name__: cls for cls in RULE_MODEL_CLASSES
+}
+
+AnyRuleSetModel = (
+    AccessPlatformRuleSet
+    | ActivityRuleSet
+    | ContactPointRuleSet
+    | DistributionRuleSet
+    | OrganizationRuleSet
+    | OrganizationalUnitRuleSet
+    | PersonRuleSet
+    | PrimarySourceRuleSet
+    | ResourceRuleSet
+    | VariableRuleSet
+    | VariableGroupRuleSet
+)
+RULE_SET_MODEL_CLASSES: Final[list[type[AnyRuleSetModel]]] = list(
+    get_args(AnyRuleSetModel)
+)
+RULE_SET_MODEL_CLASSES_BY_NAME: Final[dict[str, type[AnyRuleSetModel]]] = {
+    cls.__name__: cls for cls in RULE_SET_MODEL_CLASSES
 }
 
 FILTER_MODEL_BY_EXTRACTED_CLASS_NAME = {

--- a/mex/common/models/access_platform.py
+++ b/mex/common/models/access_platform.py
@@ -10,6 +10,7 @@ from mex.common.models.merged_item import MergedItem
 from mex.common.models.rules import (
     AdditiveRule,
     PreventiveRule,
+    RuleSet,
     SubtractiveRule,
 )
 from mex.common.types import (
@@ -149,3 +150,14 @@ class PreventiveAccessPlatform(_Stem, PreventiveRule):
     technicalAccessibility: list[MergedPrimarySourceIdentifier] = []
     title: list[MergedPrimarySourceIdentifier] = []
     unitInCharge: list[MergedPrimarySourceIdentifier] = []
+
+
+class AccessPlatformRuleSet(_Stem, RuleSet):
+    """Set of rules to edit an access platform item."""
+
+    entityType: Annotated[
+        Literal["AccessPlatformRuleSet"], Field(alias="$type", frozen=True)
+    ] = "AccessPlatformRuleSet"
+    additive: AdditiveAccessPlatform
+    subtractive: SubtractiveAccessPlatform
+    preventive: PreventiveAccessPlatform

--- a/mex/common/models/activity.py
+++ b/mex/common/models/activity.py
@@ -13,6 +13,7 @@ from mex.common.models.merged_item import MergedItem
 from mex.common.models.rules import (
     AdditiveRule,
     PreventiveRule,
+    RuleSet,
     SubtractiveRule,
 )
 from mex.common.types import (
@@ -162,3 +163,14 @@ class PreventiveActivity(_Stem, PreventiveRule):
     theme: list[MergedPrimarySourceIdentifier] = []
     title: list[MergedPrimarySourceIdentifier] = []
     website: list[MergedPrimarySourceIdentifier] = []
+
+
+class ActivityRuleSet(_Stem, RuleSet):
+    """Set of rules to edit an activity item."""
+
+    entityType: Annotated[
+        Literal["ActivityRuleSet"], Field(alias="$type", frozen=True)
+    ] = "ActivityRuleSet"
+    additive: AdditiveActivity
+    subtractive: SubtractiveActivity
+    preventive: PreventiveActivity

--- a/mex/common/models/contact_point.py
+++ b/mex/common/models/contact_point.py
@@ -10,6 +10,7 @@ from mex.common.models.merged_item import MergedItem
 from mex.common.models.rules import (
     AdditiveRule,
     PreventiveRule,
+    RuleSet,
     SubtractiveRule,
 )
 from mex.common.types import (
@@ -90,3 +91,14 @@ class PreventiveContactPoint(_Stem, PreventiveRule):
         Literal["PreventiveContactPoint"], Field(alias="$type", frozen=True)
     ] = "PreventiveContactPoint"
     email: list[MergedPrimarySourceIdentifier] = []
+
+
+class ContactPointRuleSet(_Stem, RuleSet):
+    """Set of rules to edit a contact point item."""
+
+    entityType: Annotated[
+        Literal["ContactPointRuleSet"], Field(alias="$type", frozen=True)
+    ] = "ContactPointRuleSet"
+    additive: AdditiveContactPoint
+    subtractive: SubtractiveContactPoint
+    preventive: PreventiveContactPoint

--- a/mex/common/models/distribution.py
+++ b/mex/common/models/distribution.py
@@ -7,7 +7,12 @@ from pydantic import Field, computed_field
 from mex.common.models.base import BaseModel
 from mex.common.models.extracted_data import ExtractedData
 from mex.common.models.merged_item import MergedItem
-from mex.common.models.rules import AdditiveRule, PreventiveRule, SubtractiveRule
+from mex.common.models.rules import (
+    AdditiveRule,
+    PreventiveRule,
+    RuleSet,
+    SubtractiveRule,
+)
 from mex.common.types import (
     AccessRestriction,
     ExtractedDistributionIdentifier,
@@ -203,3 +208,14 @@ class PreventiveDistribution(_Stem, PreventiveRule):
     publisher: list[MergedPrimarySourceIdentifier] = []
     researcher: list[MergedPrimarySourceIdentifier] = []
     title: list[MergedPrimarySourceIdentifier] = []
+
+
+class DistributionRuleSet(_Stem, RuleSet):
+    """Set of rules to edit a distribution item."""
+
+    entityType: Annotated[
+        Literal["DistributionRuleSet"], Field(alias="$type", frozen=True)
+    ] = "DistributionRuleSet"
+    additive: AdditiveDistribution
+    subtractive: SubtractiveDistribution
+    preventive: PreventiveDistribution

--- a/mex/common/models/organization.py
+++ b/mex/common/models/organization.py
@@ -10,7 +10,12 @@ from pydantic import Field, computed_field
 from mex.common.models.base import BaseModel
 from mex.common.models.extracted_data import ExtractedData
 from mex.common.models.merged_item import MergedItem
-from mex.common.models.rules import AdditiveRule, PreventiveRule, SubtractiveRule
+from mex.common.models.rules import (
+    AdditiveRule,
+    PreventiveRule,
+    RuleSet,
+    SubtractiveRule,
+)
 from mex.common.types import (
     ExtractedOrganizationIdentifier,
     MergedOrganizationIdentifier,
@@ -162,3 +167,14 @@ class PreventiveOrganization(_Stem, PreventiveRule):
     shortName: list[MergedPrimarySourceIdentifier] = []
     viafId: list[MergedPrimarySourceIdentifier] = []
     wikidataId: list[MergedPrimarySourceIdentifier] = []
+
+
+class OrganizationRuleSet(_Stem, RuleSet):
+    """Set of rules to edit an organization item."""
+
+    entityType: Annotated[
+        Literal["OrganizationRuleSet"], Field(alias="$type", frozen=True)
+    ] = "OrganizationRuleSet"
+    additive: AdditiveOrganization
+    subtractive: SubtractiveOrganization
+    preventive: PreventiveOrganization

--- a/mex/common/models/organizational_unit.py
+++ b/mex/common/models/organizational_unit.py
@@ -7,7 +7,12 @@ from pydantic import Field, computed_field
 from mex.common.models.base import BaseModel
 from mex.common.models.extracted_data import ExtractedData
 from mex.common.models.merged_item import MergedItem
-from mex.common.models.rules import AdditiveRule, PreventiveRule, SubtractiveRule
+from mex.common.models.rules import (
+    AdditiveRule,
+    PreventiveRule,
+    RuleSet,
+    SubtractiveRule,
+)
 from mex.common.types import (
     Email,
     ExtractedOrganizationalUnitIdentifier,
@@ -115,3 +120,14 @@ class PreventiveOrganizationalUnit(_Stem, PreventiveRule):
     shortName: list[MergedPrimarySourceIdentifier] = []
     unitOf: list[MergedPrimarySourceIdentifier] = []
     website: list[MergedPrimarySourceIdentifier] = []
+
+
+class OrganizationalUnitRuleSet(_Stem, RuleSet):
+    """Set of rules to edit an organizational unit item."""
+
+    entityType: Annotated[
+        Literal["OrganizationalUnitRuleSet"], Field(alias="$type", frozen=True)
+    ] = "OrganizationalUnitRuleSet"
+    additive: AdditiveOrganizationalUnit
+    subtractive: SubtractiveOrganizationalUnit
+    preventive: PreventiveOrganizationalUnit

--- a/mex/common/models/person.py
+++ b/mex/common/models/person.py
@@ -7,7 +7,12 @@ from pydantic import Field, computed_field
 from mex.common.models.base import BaseModel
 from mex.common.models.extracted_data import ExtractedData
 from mex.common.models.merged_item import MergedItem
-from mex.common.models.rules import AdditiveRule, PreventiveRule, SubtractiveRule
+from mex.common.models.rules import (
+    AdditiveRule,
+    PreventiveRule,
+    RuleSet,
+    SubtractiveRule,
+)
 from mex.common.types import (
     Email,
     ExtractedPersonIdentifier,
@@ -135,3 +140,14 @@ class PreventivePerson(_Stem, PreventiveRule):
     isniId: list[MergedPrimarySourceIdentifier] = []
     memberOf: list[MergedPrimarySourceIdentifier] = []
     orcidId: list[MergedPrimarySourceIdentifier] = []
+
+
+class PersonRuleSet(_Stem, RuleSet):
+    """Set of rules to edit a person item."""
+
+    entityType: Annotated[
+        Literal["PersonRuleSet"], Field(alias="$type", frozen=True)
+    ] = "PersonRuleSet"
+    additive: AdditivePerson
+    subtractive: SubtractivePerson
+    preventive: PreventivePerson

--- a/mex/common/models/primary_source.py
+++ b/mex/common/models/primary_source.py
@@ -7,7 +7,12 @@ from pydantic import Field, computed_field
 from mex.common.models.base import BaseModel
 from mex.common.models.extracted_data import ExtractedData
 from mex.common.models.merged_item import MergedItem
-from mex.common.models.rules import AdditiveRule, PreventiveRule, SubtractiveRule
+from mex.common.models.rules import (
+    AdditiveRule,
+    PreventiveRule,
+    RuleSet,
+    SubtractiveRule,
+)
 from mex.common.types import (
     ExtractedPrimarySourceIdentifier,
     Link,
@@ -125,3 +130,14 @@ class PreventivePrimarySource(_Stem, PreventiveRule):
     title: list[MergedPrimarySourceIdentifier] = []
     unitInCharge: list[MergedPrimarySourceIdentifier] = []
     version: list[MergedPrimarySourceIdentifier] = []
+
+
+class PrimarySourceRuleSet(_Stem, RuleSet):
+    """Set of rules to edit an primary source item."""
+
+    entityType: Annotated[
+        Literal["PrimarySourceRuleSet"], Field(alias="$type", frozen=True)
+    ] = "PrimarySourceRuleSet"
+    additive: AdditivePrimarySource
+    subtractive: SubtractivePrimarySource
+    preventive: PreventivePrimarySource

--- a/mex/common/models/resource.py
+++ b/mex/common/models/resource.py
@@ -7,7 +7,12 @@ from pydantic import Field, computed_field
 from mex.common.models.base import BaseModel
 from mex.common.models.extracted_data import ExtractedData
 from mex.common.models.merged_item import MergedItem
-from mex.common.models.rules import AdditiveRule, PreventiveRule, SubtractiveRule
+from mex.common.models.rules import (
+    AdditiveRule,
+    PreventiveRule,
+    RuleSet,
+    SubtractiveRule,
+)
 from mex.common.types import (
     AccessRestriction,
     AnonymizationPseudonymization,
@@ -320,3 +325,14 @@ class PreventiveResource(_Stem, PreventiveRule):
     title: list[MergedPrimarySourceIdentifier] = []
     unitInCharge: list[MergedPrimarySourceIdentifier] = []
     wasGeneratedBy: list[MergedPrimarySourceIdentifier] = []
+
+
+class ResourceRuleSet(_Stem, RuleSet):
+    """Set of rules to edit a resource item."""
+
+    entityType: Annotated[
+        Literal["ResourceRuleSet"], Field(alias="$type", frozen=True)
+    ] = "ResourceRuleSet"
+    additive: AdditiveResource
+    subtractive: SubtractiveResource
+    preventive: PreventiveResource

--- a/mex/common/models/rules.py
+++ b/mex/common/models/rules.py
@@ -11,3 +11,7 @@ class SubtractiveRule(BaseEntity):
 
 class PreventiveRule(BaseEntity):
     """Base rule to prevent primary sources for fields of merged items."""
+
+
+class RuleSet(BaseEntity):
+    """Base class for a set of an additive, subtractive and preventive rule."""

--- a/mex/common/models/variable.py
+++ b/mex/common/models/variable.py
@@ -7,7 +7,12 @@ from pydantic import Field, computed_field
 from mex.common.models.base import BaseModel
 from mex.common.models.extracted_data import ExtractedData
 from mex.common.models.merged_item import MergedItem
-from mex.common.models.rules import AdditiveRule, PreventiveRule, SubtractiveRule
+from mex.common.models.rules import (
+    AdditiveRule,
+    PreventiveRule,
+    RuleSet,
+    SubtractiveRule,
+)
 from mex.common.types import (
     DataType,
     ExtractedVariableIdentifier,
@@ -175,3 +180,14 @@ class PreventiveVariable(_Stem, PreventiveRule):
     label: list[MergedPrimarySourceIdentifier] = []
     usedIn: list[MergedPrimarySourceIdentifier] = []
     valueSet: list[MergedPrimarySourceIdentifier] = []
+
+
+class VariableRuleSet(_Stem, RuleSet):
+    """Set of rules to edit a variable item."""
+
+    entityType: Annotated[
+        Literal["VariableRuleSet"], Field(alias="$type", frozen=True)
+    ] = "VariableRuleSet"
+    additive: AdditiveVariable
+    subtractive: SubtractiveVariable
+    preventive: PreventiveVariable

--- a/mex/common/models/variable_group.py
+++ b/mex/common/models/variable_group.py
@@ -7,7 +7,12 @@ from pydantic import Field, computed_field
 from mex.common.models.base import BaseModel
 from mex.common.models.extracted_data import ExtractedData
 from mex.common.models.merged_item import MergedItem
-from mex.common.models.rules import AdditiveRule, PreventiveRule, SubtractiveRule
+from mex.common.models.rules import (
+    AdditiveRule,
+    PreventiveRule,
+    RuleSet,
+    SubtractiveRule,
+)
 from mex.common.types import (
     ExtractedVariableGroupIdentifier,
     MergedPrimarySourceIdentifier,
@@ -90,3 +95,14 @@ class PreventiveVariableGroup(_Stem, PreventiveRule):
     ] = "PreventiveVariableGroup"
     containedBy: list[MergedPrimarySourceIdentifier] = []
     label: list[MergedPrimarySourceIdentifier] = []
+
+
+class VariableGroupRuleSet(_Stem, RuleSet):
+    """Set of rules to edit a variable group item."""
+
+    entityType: Annotated[
+        Literal["VariableGroupRuleSet"], Field(alias="$type", frozen=True)
+    ] = "VariableGroupRuleSet"
+    additive: AdditiveVariableGroup
+    subtractive: SubtractiveVariableGroup
+    preventive: PreventiveVariableGroup


### PR DESCRIPTION
# PR Context
- prep for https://github.com/robert-koch-institut/mex-backend/pull/114
- moved to mex-common because they will be used by backend and editor

# Added
- models for rule sets along with typing and lookups
