### PR TITLE
Bump cookiecutter template to 6c948a

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "checkout": null,
-  "commit": "cf7f28ed2a2abbeb6b7eb2319e5c894d7020d675",
+  "commit": "6c948ad23a4e80d9861eeac8f522af3fb18e3db8",
   "context": {
     "cookiecutter": {
       "project_name": "common",

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *.cover
+*.jpeg
 *.py,cover
 .hypothesis/
 .pytest_cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ distribution = true
 
 [tool.pdm.scripts]
 update-all = { cmd = "pdm update --group :all --update-all --save-compatible" }
-lock-all = { cmd = "pdm lock --group :all --refresh" }
+lock-all = { cmd = "pdm lock --group :all --python='==3.11.*'" }
 install-all = { cmd = "pdm install --group :all --frozen-lockfile" }
 export-all = { cmd = "pdm export --group :all --no-hashes -f requirements" }
 apidoc = { cmd = "pdm run sphinx-apidoc -f -o docs/source mex" }


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/6c948a
