### PR TITLE
Bump cookiecutter template to a782ed

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "checkout": null,
-  "commit": "d4069ccba84c939a50651947e12cf36e2e9ce1aa",
+  "commit": "a782ed7ea131e6d0cd67d4cc81975f2328228bcd",
   "context": {
     "cookiecutter": {
       "project_name": "common",


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/a782ed

# Conflicts

```diff a/.github/workflows/release.yml b/.github/workflows/release.yml	(rejected hunks)
@@ -114,7 +114,7 @@ jobs:
           pdm export --self --output locked-requirements.txt --no-hashes --without dev
 
       - name: 'Login to GitHub Container Registry'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{github.actor}}
```
