### PR TITLE
feature/mx-1417 fix temporal serialization

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "checkout": null,
-  "commit": "d4069ccba84c939a50651947e12cf36e2e9ce1aa",
+  "commit": "a782ed7ea131e6d0cd67d4cc81975f2328228bcd",
   "context": {
     "cookiecutter": {
       "project_name": "common",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 - update cruft and loosen up pyproject dependencies
+- harmonize signatures/docs of pydantic core/json schema manipulating methods
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- fix schema tests not starting with diverging model names in common and mex-model
+- fix serialization for temporal entity instances within pydantic models
 
 ### Security
 

--- a/mex/common/types/email.py
+++ b/mex/common/types/email.py
@@ -1,7 +1,6 @@
 from typing import Any
 
-from pydantic import GetJsonSchemaHandler
-from pydantic.json_schema import JsonSchemaValue
+from pydantic import GetJsonSchemaHandler, json_schema
 from pydantic_core import core_schema
 
 EMAIL_PATTERN = r"^[^@ \t\r\n]+@[^@ \t\r\n]+\.[^@ \t\r\n]+$"
@@ -11,17 +10,21 @@ class Email(str):
     """Email address of a person, organization or other entity."""
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, _source: type[Any]) -> core_schema.CoreSchema:
-        """Get pydantic core schema."""
+    def __get_pydantic_core_schema__(cls, source: type[Any]) -> core_schema.CoreSchema:
+        """Modify the core schema to add the email regex."""
         return core_schema.str_schema(pattern=EMAIL_PATTERN)
 
     @classmethod
     def __get_pydantic_json_schema__(
         cls, core_schema_: core_schema.CoreSchema, handler: GetJsonSchemaHandler
-    ) -> JsonSchemaValue:
-        """Add title and format."""
-        field_schema = handler(core_schema_)
-        field_schema["title"] = cls.__name__
-        field_schema["format"] = "email"
-        field_schema["examples"] = ["info@rki.de"]
-        return field_schema
+    ) -> json_schema.JsonSchemaValue:
+        """Modify the json schema to add a title, format and examples."""
+        json_schema_ = handler(core_schema_)
+        json_schema_["title"] = cls.__name__
+        json_schema_["format"] = "email"
+        json_schema_["examples"] = ["info@rki.de"]
+        return json_schema_
+
+    def __repr__(self) -> str:
+        """Overwrite the default representation."""
+        return f"{self.__class__.__name__}({super().__str__().__repr__()})"

--- a/mex/common/types/path.py
+++ b/mex/common/types/path.py
@@ -49,7 +49,7 @@ class PathWrapper(PathLike[str]):
         return not self._path.is_absolute()
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, _source: type[Any]) -> core_schema.CoreSchema:
+    def __get_pydantic_core_schema__(cls, source: type[Any]) -> core_schema.CoreSchema:
         """Set schema to str schema."""
         from_str_schema = core_schema.chain_schema(
             [

--- a/tests/models/test_model_schemas.py
+++ b/tests/models/test_model_schemas.py
@@ -67,8 +67,8 @@ def test_entity_types_match_spec() -> None:
 
 @pytest.mark.parametrize(
     ("generated", "specified"),
-    zip_longest(GENERATED_SCHEMAS.values(), SPECIFIED_SCHEMAS.values()),
-    ids=GENERATED_SCHEMAS,
+    zip_longest(GENERATED_SCHEMAS.values(), SPECIFIED_SCHEMAS.values(), fillvalue={}),
+    ids=map(str, zip_longest(GENERATED_SCHEMAS, SPECIFIED_SCHEMAS, fillvalue="N/A")),
 )
 def test_field_names_match_spec(
     generated: dict[str, Any], specified: dict[str, Any]
@@ -81,8 +81,8 @@ def test_field_names_match_spec(
 
 @pytest.mark.parametrize(
     ("generated", "specified"),
-    zip_longest(GENERATED_SCHEMAS.values(), SPECIFIED_SCHEMAS.values()),
-    ids=GENERATED_SCHEMAS,
+    zip_longest(GENERATED_SCHEMAS.values(), SPECIFIED_SCHEMAS.values(), fillvalue={}),
+    ids=map(str, zip_longest(GENERATED_SCHEMAS, SPECIFIED_SCHEMAS, fillvalue="N/A")),
 )
 def test_entity_type_matches_class_name(
     generated: dict[str, Any], specified: dict[str, Any]
@@ -95,8 +95,8 @@ def test_entity_type_matches_class_name(
 
 @pytest.mark.parametrize(
     ("generated", "specified"),
-    zip_longest(GENERATED_SCHEMAS.values(), SPECIFIED_SCHEMAS.values()),
-    ids=GENERATED_SCHEMAS,
+    zip_longest(GENERATED_SCHEMAS.values(), SPECIFIED_SCHEMAS.values(), fillvalue={}),
+    ids=map(str, zip_longest(GENERATED_SCHEMAS, SPECIFIED_SCHEMAS, fillvalue="N/A")),
 )
 def test_required_fields_match_spec(
     generated: dict[str, Any], specified: dict[str, Any]

--- a/tests/types/test_temporal_entity.py
+++ b/tests/types/test_temporal_entity.py
@@ -2,6 +2,7 @@ from datetime import date, datetime
 from typing import Any
 
 import pytest
+from pydantic import BaseModel
 from pytz import timezone
 
 from mex.common.types import (
@@ -268,3 +269,12 @@ def test_temporal_entity_repr() -> None:
         repr(YearMonthDayTime("2018-03-02T12:00:01Z"))
         == 'YearMonthDayTime("2018-03-02T12:00:01Z")'
     )
+
+
+def test_temporal_entity_serialization() -> None:
+    class Person(BaseModel):
+        birthday: YearMonthDay
+
+    person = Person.model_validate({"birthday": "24th July 1999"})
+
+    assert person.model_dump_json() == '{"birthday":"1999-07-24"}'

--- a/tests/wikidata/test_connector.py
+++ b/tests/wikidata/test_connector.py
@@ -25,6 +25,22 @@ def test_get_data_by_query() -> None:
     """Test if items can be searched providing a label."""
     expected = [
         {
+            "item": {
+                "type": "uri",
+                "value": "http://www.wikidata.org/entity/Q2875797",
+            },
+            "itemDescription": {
+                "type": "literal",
+                "value": "airport in Algeria",
+                "xml:lang": "en",
+            },
+            "itemLabel": {
+                "type": "literal",
+                "value": "Bordj Mokhtar Airport",
+                "xml:lang": "en",
+            },
+        },
+        {
             "item": {"type": "uri", "value": "http://www.wikidata.org/entity/Q26678"},
             "itemDescription": {
                 "type": "literal",


### PR DESCRIPTION
# PR Context
- fixes https://github.com/robert-koch-institut/mex-backend/pull/106#pullrequestreview-2244970390

# Changes

- harmonize signatures/docs of pydantic core/json schema manipulating methods

# Fixed

- fix schema tests not starting with diverging model names in common and mex-model
- fix serialization for temporal entity instances within pydantic models
