### PR TITLE
Bump cookiecutter template to cee205

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "checkout": null,
-  "commit": "a782ed7ea131e6d0cd67d4cc81975f2328228bcd",
+  "commit": "cee205846b2eb6f25e1ce762f395aa50ccbbf93e",
   "context": {
     "cookiecutter": {
       "project_name": "common",


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/cee205
