### PR TITLE
Bump cookiecutter template to bae864

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "checkout": null,
-  "commit": "cee205846b2eb6f25e1ce762f395aa50ccbbf93e",
+  "commit": "bae86448088992cdbd3acde751ad7aa19a79d71b",
   "context": {
     "cookiecutter": {
       "project_name": "common",


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/bae864
