### PR TITLE
hotfix/fix bibliographic resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fix typo in `repositoryURL` of bibliographic resources
+- make identifier and stableTargetId of ExtractedBibliographicResource computed fields
+
 ### Security
 
 ## [0.39.0] - 2024-10-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- upgrade mex-model dependency to version 3.1
+
 ### Deprecated
 
 ### Removed

--- a/mex/common/models/bibliographic_resource.py
+++ b/mex/common/models/bibliographic_resource.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated, ClassVar, Literal
 
-from pydantic import Field
+from pydantic import Field, computed_field
 
 from mex.common.models.base.extracted_data import ExtractedData
 from mex.common.models.base.merged_item import MergedItem
@@ -158,7 +158,7 @@ class _OptionalValues(_Stem):
     ) = None
     publicationPlace: PublicationPlaceStr | None = None
     publicationYear: Year | None = None
-    respositoryURL: Link | None = None
+    repositoryURL: Link | None = None
     section: SectionStr | None = None
     volume: VolumeOrIssueStr | None = None
     volumeOfSeries: VolumeOrIssueStr | None = None
@@ -184,7 +184,7 @@ class _VariadicValues(_Stem):
     ] = []
     publicationPlace: list[PublicationPlaceStr] = []
     publicationYear: list[Year] = []
-    respositoryURL: list[Link] = []
+    repositoryURL: list[Link] = []
     section: list[SectionStr] = []
     volume: list[VolumeOrIssueStr] = []
     volumeOfSeries: list[VolumeOrIssueStr] = []
@@ -202,8 +202,18 @@ class ExtractedBibliographicResource(BaseBibliographicResource, ExtractedData):
     entityType: Annotated[
         Literal["ExtractedBibliographicResource"], Field(alias="$type", frozen=True)
     ] = "ExtractedBibliographicResource"
-    identifier: Annotated[ExtractedBibliographicResourceIdentifier, Field(frozen=True)]
-    stableTargetId: MergedBibliographicResourceIdentifier
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def identifier(self) -> ExtractedBibliographicResourceIdentifier:
+        """Return the computed identifier for this extracted data item."""
+        return self._get_identifier(ExtractedBibliographicResourceIdentifier)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def stableTargetId(self) -> MergedBibliographicResourceIdentifier:  # noqa: N802
+        """Return the computed stableTargetId for this extracted data item."""
+        return self._get_stable_target_id(MergedBibliographicResourceIdentifier)
 
 
 class MergedBibliographicResource(BaseBibliographicResource, MergedItem):
@@ -264,7 +274,7 @@ class PreventiveBibliographicResource(_Stem, PreventiveRule):
     publicationPlace: list[MergedPrimarySourceIdentifier] = []
     publicationYear: list[MergedPrimarySourceIdentifier] = []
     publisher: list[MergedPrimarySourceIdentifier] = []
-    respositoryURL: list[MergedPrimarySourceIdentifier] = []
+    repositoryURL: list[MergedPrimarySourceIdentifier] = []
     section: list[MergedPrimarySourceIdentifier] = []
     subtitle: list[MergedPrimarySourceIdentifier] = []
     title: list[MergedPrimarySourceIdentifier] = []

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:df21ff96428de0ee0cd54fe1a7017e755ad04012edc31c84a229cef71fb0f46a"
+content_hash = "sha256:963fa72feed9cb31e5b7d42bb995153e70aaa25ca30d47f277a52e63fd07250e"
 
 [[metadata.targets]]
 requires_python = "==3.11.*"
@@ -429,11 +429,11 @@ files = [
 
 [[package]]
 name = "mex-model"
-version = "3.0.0"
+version = "3.1.0"
 requires_python = "<3.13,>=3.11"
 git = "https://github.com/robert-koch-institut/mex-model.git"
-ref = "3.0.0"
-revision = "c027f6e13b599624c085cd3d383a8ad902d8ba51"
+ref = "3.1.0"
+revision = "61283bbb386573e18db79ec86dbc03363b4348ce"
 summary = "JSON schema files defining the MEx metadata model."
 groups = ["default"]
 marker = "python_version == \"3.11\""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "click>=8.1.7,<9",
     "langdetect>=1.0.9,<2",
     "ldap3>=2.9.1,<3",
-    "mex-model @ git+https://github.com/robert-koch-institut/mex-model.git@3.0.0",
+    "mex-model @ git+https://github.com/robert-koch-institut/mex-model.git@3.1.0",
     "numpy>=2.1.2,<3",
     "pandas>=2.2.3,<3",
     "pyarrow>=17.0.0,<18",


### PR DESCRIPTION
### Changes

- upgrade mex-model dependency to version 3.1

### Fixed

- fix typo in `repositoryURL` of bibliographic resources
- make identifier and stableTargetId of ExtractedBibliographicResource computed fields
