### PR TITLE
Bump cookiecutter template to fca460

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "checkout": null,
-  "commit": "382febffff2ead8fd4d1e66b411a1cd39a192446",
+  "commit": "fca460e90134ef8c10f54d491aa80891509b1b6c",
   "context": {
     "cookiecutter": {
       "project_name": "common",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,5 @@
 cruft==2.15.0
 mex-release @ git+https://github.com/robert-koch-institut/mex-release.git
-<<<<<<< ours
-pdm==2.19.3
-=======
 pdm==2.19.1
->>>>>>> theirs
 pre-commit==4.0.1
 wheel==0.44.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,9 @@
 cruft==2.15.0
 mex-release @ git+https://github.com/robert-koch-institut/mex-release.git
+<<<<<<< ours
 pdm==2.19.3
+=======
+pdm==2.19.1
+>>>>>>> theirs
 pre-commit==4.0.1
 wheel==0.44.0


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/fca460
