### PR TITLE
Feature/mx 1332 organigram check for duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- organigram extraction checks for duplicate emails/labels in different organigram units
 
 ### Changes
 

--- a/mex/common/backend_api/connector.py
+++ b/mex/common/backend_api/connector.py
@@ -140,7 +140,7 @@ class BackendApiConnector(HTTPConnector):
             identifier: The merged item's identifier
 
         Raises:
-            MExError: If no merged item was found
+            HTTPError: If no merged item was found
 
         Returns:
             A single merged item

--- a/mex/common/organigram/extract.py
+++ b/mex/common/organigram/extract.py
@@ -99,7 +99,7 @@ def get_unit_merged_ids_by_emails(
                 and email_dict[lower_email] != extracted_unit.stableTargetId
             ):
                 msg = (
-                    f"Conflict: email {email} is associated with merged unit IDs "
+                    f"Conflict: email '{email}' is associated with merged unit IDs "
                     f"{email_dict[lower_email]} and {extracted_unit.stableTargetId}."
                 )
                 raise MExError(msg)

--- a/mex/common/organigram/extract.py
+++ b/mex/common/organigram/extract.py
@@ -52,7 +52,7 @@ def get_unit_merged_ids_by_synonyms(
     """Return a mapping from unit alt_label and label to their merged IDs.
 
     There will be multiple entries per unit mapping to the same merged ID.
-    But if the same entry mapps to differnt merged unit IDs, an error is thrown.
+    But if the same entry mapps to different merged IDs, an error is thrown.
 
     Args:
         extracted_units: Iterable of extracted units
@@ -68,7 +68,7 @@ def get_unit_merged_ids_by_synonyms(
                 and synonym_dict[synonym] != extracted_unit.stableTargetId
             ):
                 msg = (
-                    f"Conflict: label '{synonym}' is associated with merged unit ID "
+                    f"Conflict: label '{synonym}' is associated with merged unit IDs "
                     f"{synonym_dict[synonym]} and {extracted_unit.stableTargetId}."
                 )
                 raise MExError(msg)
@@ -82,7 +82,7 @@ def get_unit_merged_ids_by_emails(
     """Return a mapping from unit emails to their merged IDs.
 
     There may be multiple emails per unit mapping to the same merged ID.
-    But if the same email mapps to differnt merged unit IDs, an error is thrown.
+    But if the same email mapps to different merged IDs, an error is thrown.
 
     Args:
         extracted_units: Iterable of extracted units
@@ -99,7 +99,7 @@ def get_unit_merged_ids_by_emails(
                 and email_dict[lower_email] != extracted_unit.stableTargetId
             ):
                 msg = (
-                    f"Conflict: email {email} is associated with merged unit ID "
+                    f"Conflict: email {email} is associated with merged unit IDs "
                     f"{email_dict[lower_email]} and {extracted_unit.stableTargetId}."
                 )
                 raise MExError(msg)

--- a/mex/common/organigram/extract.py
+++ b/mex/common/organigram/extract.py
@@ -1,6 +1,7 @@
 import json
 from collections.abc import Generator, Iterable
 
+from mex.common.exceptions import MExError
 from mex.common.logging import watch
 from mex.common.models import ExtractedOrganizationalUnit
 from mex.common.organigram.models import OrganigramUnit
@@ -51,6 +52,7 @@ def get_unit_merged_ids_by_synonyms(
     """Return a mapping from unit alt_label and label to their merged IDs.
 
     There will be multiple entries per unit mapping to the same merged ID.
+    But if the same entry mapps to differnt merged unit IDs, an error is thrown.
 
     Args:
         extracted_units: Iterable of extracted units
@@ -58,11 +60,20 @@ def get_unit_merged_ids_by_synonyms(
     Returns:
         Mapping from unit synonyms to stableTargetIds
     """
-    return {
-        synonym: MergedOrganizationalUnitIdentifier(extracted_unit.stableTargetId)
-        for extracted_unit in extracted_units
-        for synonym in _get_synonyms(extracted_unit)
-    }
+    synonym_dict: dict[str, MergedOrganizationalUnitIdentifier] = {}
+    for extracted_unit in extracted_units:
+        for synonym in _get_synonyms(extracted_unit):
+            if (
+                synonym in synonym_dict
+                and synonym_dict[synonym] != extracted_unit.stableTargetId
+            ):
+                msg = (
+                    f"Conflict: label '{synonym}' is associated with merged unit ID "
+                    f"{synonym_dict[synonym]} and {extracted_unit.stableTargetId}."
+                )
+                raise MExError(msg)
+            synonym_dict[synonym] = extracted_unit.stableTargetId
+    return synonym_dict
 
 
 def get_unit_merged_ids_by_emails(
@@ -71,6 +82,7 @@ def get_unit_merged_ids_by_emails(
     """Return a mapping from unit emails to their merged IDs.
 
     There may be multiple emails per unit mapping to the same merged ID.
+    But if the same email mapps to differnt merged unit IDs, an error is thrown.
 
     Args:
         extracted_units: Iterable of extracted units
@@ -78,8 +90,18 @@ def get_unit_merged_ids_by_emails(
     Returns:
         Mapping from lowercased `email` to stableTargetIds
     """
-    return {
-        email.lower(): MergedOrganizationalUnitIdentifier(extracted_unit.stableTargetId)
-        for extracted_unit in extracted_units
-        for email in extracted_unit.email
-    }
+    email_dict: dict[str, MergedOrganizationalUnitIdentifier] = {}
+    for extracted_unit in extracted_units:
+        for email in extracted_unit.email:
+            lower_email = email.lower()
+            if (
+                lower_email in email_dict
+                and email_dict[lower_email] != extracted_unit.stableTargetId
+            ):
+                msg = (
+                    f"Conflict: email {email} is associated with merged unit ID "
+                    f"{email_dict[lower_email]} and {extracted_unit.stableTargetId}."
+                )
+                raise MExError(msg)
+            email_dict[lower_email] = extracted_unit.stableTargetId
+    return email_dict

--- a/mex/common/organigram/extract.py
+++ b/mex/common/organigram/extract.py
@@ -84,7 +84,6 @@ def get_unit_merged_ids_by_emails(
     """Return a mapping from unit emails to their merged IDs.
 
     There may be multiple emails per unit mapping to the same merged ID.
-    But if the same email maps to different merged IDs, an error is thrown.
 
     Args:
         extracted_units: Iterable of extracted units

--- a/mex/common/organigram/extract.py
+++ b/mex/common/organigram/extract.py
@@ -52,10 +52,12 @@ def get_unit_merged_ids_by_synonyms(
     """Return a mapping from unit alt_label and label to their merged IDs.
 
     There will be multiple entries per unit mapping to the same merged ID.
-    But if the same entry mapps to different merged IDs, an error is thrown.
 
     Args:
         extracted_units: Iterable of extracted units
+
+    Raises:
+        MExError: If the same entry maps to different merged IDs
 
     Returns:
         Mapping from unit synonyms to stableTargetIds
@@ -82,10 +84,13 @@ def get_unit_merged_ids_by_emails(
     """Return a mapping from unit emails to their merged IDs.
 
     There may be multiple emails per unit mapping to the same merged ID.
-    But if the same email mapps to different merged IDs, an error is thrown.
+    But if the same email maps to different merged IDs, an error is thrown.
 
     Args:
         extracted_units: Iterable of extracted units
+
+    Raises:
+        MExError: If the same entry maps to different merged IDs
 
     Returns:
         Mapping from lowercased `email` to stableTargetIds

--- a/tests/organigram/test_extract.py
+++ b/tests/organigram/test_extract.py
@@ -65,8 +65,9 @@ def test_get_unit_merged_ids_by_emails_error(
     erroneus_extracted_child_unit.email.append("PARENT@example.com")
 
     msg = (
-        "MExError: Conflict: email PARENT@example.com is associated with "
-        "merged unit IDs 6rqNvZSApUHlz8GkkVP48 and hIiJpZXVppHvoyeP0QtAoS."
+        f"MExError: Conflict: email 'PARENT@example.com' is associated with "
+        f"merged unit IDs {erroneus_extracted_child_unit.stableTargetId} and "
+        f"{extracted_parent_unit.stableTargetId}."
     )
     with pytest.raises(MExError, match=msg):
         get_unit_merged_ids_by_emails(

--- a/tests/organigram/test_extract.py
+++ b/tests/organigram/test_extract.py
@@ -1,3 +1,6 @@
+import pytest
+
+from mex.common.exceptions import MExError
 from mex.common.models import ExtractedOrganizationalUnit
 from mex.common.organigram.extract import (
     extract_organigram_units,
@@ -52,3 +55,20 @@ def test_get_unit_merged_ids_by_emails(
         "pu@example.com": extracted_parent_unit.stableTargetId,
         # child unit has no emails
     }
+
+
+def test_get_unit_merged_ids_by_emails_error(
+    extracted_child_unit: ExtractedOrganizationalUnit,
+    extracted_parent_unit: ExtractedOrganizationalUnit,
+) -> None:
+    erroneus_extracted_child_unit = extracted_child_unit
+    erroneus_extracted_child_unit.email.append("PARENT@example.com")
+
+    msg = (
+        "MExError: Conflict: email PARENT@example.com is associated with "
+        "merged unit IDs 6rqNvZSApUHlz8GkkVP48 and hIiJpZXVppHvoyeP0QtAoS."
+    )
+    with pytest.raises(MExError, match=msg):
+        get_unit_merged_ids_by_emails(
+            [erroneus_extracted_child_unit, extracted_parent_unit]
+        )

--- a/tests/organigram/test_extract.py
+++ b/tests/organigram/test_extract.py
@@ -8,6 +8,7 @@ from mex.common.organigram.extract import (
     get_unit_merged_ids_by_synonyms,
 )
 from mex.common.organigram.models import OrganigramUnit
+from mex.common.types import Text
 
 
 def test_extract_organigram_units(
@@ -41,6 +42,24 @@ def test_get_unit_merged_ids_by_synonyms(
         "PRNT Abteilung": parent_id,
         "parent-unit": parent_id,
     }
+
+
+def test_get_unit_merged_ids_by_synonyms_error(
+    extracted_child_unit: ExtractedOrganizationalUnit,
+    extracted_parent_unit: ExtractedOrganizationalUnit,
+) -> None:
+    erroneus_extracted_child_unit = extracted_child_unit
+    erroneus_extracted_child_unit.name.append(Text(value="PARENT Dept."))
+
+    msg = (
+        f"MExError: Conflict: label 'PARENT Dept.' is associated with "
+        f"merged unit IDs {erroneus_extracted_child_unit.stableTargetId} and "
+        f"{extracted_parent_unit.stableTargetId}."
+    )
+    with pytest.raises(MExError, match=msg):
+        get_unit_merged_ids_by_synonyms(
+            [erroneus_extracted_child_unit, extracted_parent_unit]
+        )
 
 
 def test_get_unit_merged_ids_by_emails(


### PR DESCRIPTION
# Added
- organigram extraction checks for duplicate emails/labels in different organigram units
