### PR TITLE
feature/change type of distribution.title to an array of texts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
   python: python3.11
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.0
+    rev: v0.8.3
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -25,7 +25,7 @@ repos:
       - id: fix-byte-order-marker
         name: byte-order
   - repo: https://github.com/pdm-project/pdm
-    rev: 2.20.1
+    rev: 2.22.0
     hooks:
       - id: pdm-lock-check
         name: pdm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- BREAKING: change type of distribution.title to an array of texts
+
 ### Deprecated
 
 ### Removed

--- a/mex/common/models/distribution.py
+++ b/mex/common/models/distribution.py
@@ -23,6 +23,7 @@ from mex.common.types import (
     MergedDistributionIdentifier,
     MergedPrimarySourceIdentifier,
     MIMEType,
+    Text,
     Year,
     YearMonth,
     YearMonthDay,
@@ -41,6 +42,14 @@ class _OptionalLists(_Stem):
     downloadURL: list[Link] = []
 
 
+class _RequiredLists(_Stem):
+    title: Annotated[list[Text], Field(min_length=1)]
+
+
+class _SparseLists(_Stem):
+    title: list[Text] = []
+
+
 class _OptionalValues(_Stem):
     accessService: MergedAccessPlatformIdentifier | None = None
     license: License | None = None
@@ -51,28 +60,11 @@ class _OptionalValues(_Stem):
 class _RequiredValues(_Stem):
     accessRestriction: AccessRestriction
     issued: YearMonthDayTime | YearMonthDay | YearMonth | Year
-    title: Annotated[
-        str,
-        Field(
-            examples=["theNameOfTheFile"],
-            min_length=1,
-        ),
-    ]
 
 
 class _SparseValues(_Stem):
     accessRestriction: AccessRestriction | None = None
     issued: YearMonthDayTime | YearMonthDay | YearMonth | Year | None = None
-    title: (
-        Annotated[
-            str,
-            Field(
-                examples=["theNameOfTheFile"],
-                min_length=1,
-            ),
-        ]
-        | None
-    ) = None
 
 
 class _VariadicValues(_Stem):
@@ -82,18 +74,11 @@ class _VariadicValues(_Stem):
     license: list[License] = []
     mediaType: list[MIMEType] = []
     modified: list[YearMonthDayTime | YearMonthDay | YearMonth | Year] = []
-    title: list[
-        Annotated[
-            str,
-            Field(
-                examples=["theNameOfTheFile"],
-                min_length=1,
-            ),
-        ]
-    ] = []
 
 
-class BaseDistribution(_OptionalLists, _OptionalValues, _RequiredValues):
+class BaseDistribution(
+    _OptionalLists, _RequiredLists, _OptionalValues, _RequiredValues
+):
     """All fields for a valid distribution except for provenance."""
 
 
@@ -126,7 +111,9 @@ class MergedDistribution(BaseDistribution, MergedItem):
     identifier: Annotated[MergedDistributionIdentifier, Field(frozen=True)]
 
 
-class PreviewDistribution(_OptionalLists, _OptionalValues, _SparseValues, PreviewItem):
+class PreviewDistribution(
+    _OptionalLists, _SparseLists, _OptionalValues, _SparseValues, PreviewItem
+):
     """Preview for merging all extracted items and rules for a distribution."""
 
     entityType: Annotated[
@@ -136,7 +123,7 @@ class PreviewDistribution(_OptionalLists, _OptionalValues, _SparseValues, Previe
 
 
 class AdditiveDistribution(
-    _OptionalLists, _OptionalValues, _SparseValues, AdditiveRule
+    _OptionalLists, _SparseLists, _OptionalValues, _SparseValues, AdditiveRule
 ):
     """Rule to add values to merged distribution items."""
 
@@ -145,7 +132,9 @@ class AdditiveDistribution(
     ] = "AdditiveDistribution"
 
 
-class SubtractiveDistribution(_OptionalLists, _VariadicValues, SubtractiveRule):
+class SubtractiveDistribution(
+    _OptionalLists, _SparseLists, _VariadicValues, SubtractiveRule
+):
     """Rule to subtract values from merged distribution items."""
 
     entityType: Annotated[

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:94f30388b0b5a02bb7db250d607b9328308c8d5b846e168ea40b74da0542abb2"
+content_hash = "sha256:3391210e7339d6a6a1aea809d5c7ff1e4ac530eedfbd0c17b12bf685aa1da0c5"
 
 [[metadata.targets]]
 requires_python = "==3.11.*"
@@ -426,11 +426,11 @@ files = [
 
 [[package]]
 name = "mex-model"
-version = "3.3.2"
+version = "3.4.0"
 requires_python = ">=3.11,<3.13"
 git = "https://github.com/robert-koch-institut/mex-model.git"
-ref = "3.3.2"
-revision = "5e7c3dd6ee904e6727402cc1bf4663ea014cccbc"
+ref = "3.4.0"
+revision = "08d161d40c659a69c52af76b654db41f49616a24"
 summary = "JSON schema files defining the MEx metadata model."
 groups = ["default"]
 marker = "python_version == \"3.11\""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "click>=8,<9",
     "langdetect>=1,<2",
     "ldap3>=2,<3",
-    "mex-model @ git+https://github.com/robert-koch-institut/mex-model.git@3.3.2",
+    "mex-model @ git+https://github.com/robert-koch-institut/mex-model.git@3.4.0",
     "numpy>=2,<3",
     "pandas>=2,<3",
     "pyarrow>=18,<19",


### PR DESCRIPTION
# PR Context
- update to mex-model 3.4

# Changes
- BREAKING: change type of distribution.title to an array of texts
