### PR TITLE
feature/mx-1708 convert sinks to connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BREAKING: convert post_to_backend_api to BackendApiSink
 - BREAKING: convert write_ndjson to NdjsonSink
 - backend and ndjson sinks log progress only in batches
+- increase timeout and decrease chunk size for backend API sink
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- add a sink registry with `register_sink` and `get_sink` functions
+- add a `MultiSink` implementation, akin to `mex.extractors.load`
+
 ### Changes
+
+- BREAKING: convert post_to_backend_api to BackendApiSink
+- BREAKING: convert write_ndjson to NdjsonSink
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - add a sink registry with `register_sink` and `get_sink` functions
-- add a `MultiSink` implementation, akin to `mex.extractors.load`
+- add a multi-sink implementation, akin to `mex.extractors.load`
 
 ### Changes
 
 - BREAKING: convert post_to_backend_api to BackendApiSink
 - BREAKING: convert write_ndjson to NdjsonSink
+- backend and ndjson sinks log progress only in batches
 
 ### Deprecated
 

--- a/mex/common/backend_api/connector.py
+++ b/mex/common/backend_api/connector.py
@@ -25,6 +25,7 @@ class BackendApiConnector(HTTPConnector):
     """Connector class to handle interaction with the Backend API."""
 
     API_VERSION = "v0"
+    INGEST_TIMEOUT = 30
 
     def _check_availability(self) -> None:
         """Send a GET request to verify the API is available."""
@@ -59,6 +60,7 @@ class BackendApiConnector(HTTPConnector):
             method="POST",
             endpoint="ingest",
             payload=ExtractedItemsRequest(items=extracted_items),
+            timeout=self.INGEST_TIMEOUT,
         )
         return IdentifiersResponse.model_validate(response)
 

--- a/mex/common/sinks/backend_api.py
+++ b/mex/common/sinks/backend_api.py
@@ -33,4 +33,4 @@ class BackendApiSink(BaseSink, BackendApiConnector):
             response = self.post_extracted_items(model_list)
             total_count += len(model_list)
             yield from cast(list[AnyExtractedIdentifier], response.identifiers)
-            logger.info("BackendApiSink - written %s models", total_count)
+            logger.info("%s - written %s models", type(self).__name__, total_count)

--- a/mex/common/sinks/backend_api.py
+++ b/mex/common/sinks/backend_api.py
@@ -9,11 +9,10 @@ from mex.common.types import AnyExtractedIdentifier
 from mex.common.utils import grouper
 
 
-class BackendApiSink(BaseSink, BackendApiConnector):
+class BackendApiSink(BaseSink):
     """Sink to load models to the Backend API."""
 
     CHUNK_SIZE = 50
-    TIMEOUT = 30
 
     def load(
         self,
@@ -28,9 +27,10 @@ class BackendApiSink(BaseSink, BackendApiConnector):
             Generator for identifiers of posted models
         """
         total_count = 0
+        connector = BackendApiConnector.get()
         for chunk in grouper(self.CHUNK_SIZE, models):
             model_list = [model for model in chunk if model is not None]
-            response = self.post_extracted_items(model_list)
+            response = connector.post_extracted_items(model_list)
             total_count += len(model_list)
             yield from cast(list[AnyExtractedIdentifier], response.identifiers)
             logger.info("%s - written %s models", type(self).__name__, total_count)

--- a/mex/common/sinks/backend_api.py
+++ b/mex/common/sinks/backend_api.py
@@ -2,27 +2,34 @@ from collections.abc import Generator, Iterable
 from typing import cast
 
 from mex.common.backend_api.connector import BackendApiConnector
-from mex.common.logging import watch
+from mex.common.logging import logger
 from mex.common.models import AnyExtractedModel
+from mex.common.sinks.base import BaseSink
 from mex.common.types import AnyExtractedIdentifier
 from mex.common.utils import grouper
 
 
-@watch
-def post_to_backend_api(
-    models: Iterable[AnyExtractedModel], chunk_size: int = 100
-) -> Generator[AnyExtractedIdentifier, None, None]:
-    """Load models to the Backend API using bulk insertion.
+class BackendApiSink(BaseSink, BackendApiConnector):
+    """Sink to load models to the Backend API."""
 
-    Args:
-        models: Iterable of extracted models
-        chunk_size: Optional size to chunks to post in one request
+    CHUNK_SIZE = 100
 
-    Returns:
-        Generator for identifiers of posted models
-    """
-    connector = BackendApiConnector.get()
-    for chunk in grouper(chunk_size, models):
-        model_list = [model for model in chunk if model is not None]
-        response = connector.post_extracted_items(model_list)
-        yield from cast(list[AnyExtractedIdentifier], response.identifiers)
+    def load(
+        self,
+        models: Iterable[AnyExtractedModel],
+    ) -> Generator[AnyExtractedIdentifier, None, None]:
+        """Load models to the Backend API using bulk insertion.
+
+        Args:
+            models: Iterable of extracted models
+
+        Returns:
+            Generator for identifiers of posted models
+        """
+        total_count = 0
+        for chunk in grouper(self.CHUNK_SIZE, models):
+            model_list = [model for model in chunk if model is not None]
+            response = self.post_extracted_items(model_list)
+            total_count += len(model_list)
+            yield from cast(list[AnyExtractedIdentifier], response.identifiers)
+            logger.info("BackendApiSink - written %s models", total_count)

--- a/mex/common/sinks/backend_api.py
+++ b/mex/common/sinks/backend_api.py
@@ -12,7 +12,8 @@ from mex.common.utils import grouper
 class BackendApiSink(BaseSink, BackendApiConnector):
     """Sink to load models to the Backend API."""
 
-    CHUNK_SIZE = 100
+    CHUNK_SIZE = 50
+    TIMEOUT = 30
 
     def load(
         self,

--- a/mex/common/sinks/base.py
+++ b/mex/common/sinks/base.py
@@ -1,10 +1,8 @@
 from abc import abstractmethod
-from collections.abc import Generator, Iterable
-from itertools import tee
+from collections.abc import Iterable
 
 from mex.common.connector import BaseConnector
 from mex.common.models import AnyExtractedModel
-from mex.common.settings import BaseSettings
 from mex.common.types import Identifier
 
 
@@ -17,38 +15,3 @@ class BaseSink(BaseConnector):
     ) -> Iterable[Identifier]:  # pragma: no cover
         """Iteratively load models to a destination and yield their identifiers."""
         ...
-
-
-class MultiSink(BaseSink):
-    """Sink to load models to multiple sinks simultaneously."""
-
-    _sinks: list[BaseSink] = []
-
-    def __init__(self) -> None:
-        """Instantiate the multi sink singleton."""
-        # break import cycle, sigh
-        from mex.common.sinks.registry import _SINK_REGISTRY
-
-        settings = BaseSettings.get()
-        for sink in settings.sink:
-            if sink in _SINK_REGISTRY:
-                sink_cls = _SINK_REGISTRY[sink]
-                self._sinks.append(sink_cls.get())
-            else:
-                msg = f"Sink function not implemented: {sink}"
-                raise RuntimeError(msg)
-
-    def close(self) -> None:
-        """Close all underlying sinks."""
-        for sink in self._sinks:
-            sink.close()
-
-    def load(
-        self,
-        models: Iterable[AnyExtractedModel],
-    ) -> Generator[Identifier, None, None]:
-        """Load models to multiple sinks simultaneously."""
-        for sink, model_gen in zip(
-            self._sinks, tee(models, len(self._sinks)), strict=False
-        ):
-            yield from sink.load(model_gen)

--- a/mex/common/sinks/base.py
+++ b/mex/common/sinks/base.py
@@ -9,6 +9,12 @@ from mex.common.types import Identifier
 class BaseSink(BaseConnector):
     """Base class to define the interface of sink instances."""
 
+    def __init__(self) -> None:
+        """Create a new sink."""
+
+    def close(self) -> None:
+        """Close the sink."""
+
     @abstractmethod
     def load(
         self, models: Iterable[AnyExtractedModel]

--- a/mex/common/sinks/base.py
+++ b/mex/common/sinks/base.py
@@ -1,0 +1,54 @@
+from abc import abstractmethod
+from collections.abc import Generator, Iterable
+from itertools import tee
+
+from mex.common.connector import BaseConnector
+from mex.common.models import AnyExtractedModel
+from mex.common.settings import BaseSettings
+from mex.common.types import Identifier
+
+
+class BaseSink(BaseConnector):
+    """Base class to define the interface of sink instances."""
+
+    @abstractmethod
+    def load(
+        self, models: Iterable[AnyExtractedModel]
+    ) -> Iterable[Identifier]:  # pragma: no cover
+        """Iteratively load models to a destination and yield their identifiers."""
+        ...
+
+
+class MultiSink(BaseSink):
+    """Sink to load models to multiple sinks simultaneously."""
+
+    _sinks: list[BaseSink] = []
+
+    def __init__(self) -> None:
+        """Instantiate the multi sink singleton."""
+        # break import cycle, sigh
+        from mex.common.sinks.registry import _SINK_REGISTRY
+
+        settings = BaseSettings.get()
+        for sink in settings.sink:
+            if sink in _SINK_REGISTRY:
+                sink_cls = _SINK_REGISTRY[sink]
+                self._sinks.append(sink_cls.get())
+            else:
+                msg = f"Sink function not implemented: {sink}"
+                raise RuntimeError(msg)
+
+    def close(self) -> None:
+        """Close all underlying sinks."""
+        for sink in self._sinks:
+            sink.close()
+
+    def load(
+        self,
+        models: Iterable[AnyExtractedModel],
+    ) -> Generator[Identifier, None, None]:
+        """Load models to multiple sinks simultaneously."""
+        for sink, model_gen in zip(
+            self._sinks, tee(models, len(self._sinks)), strict=False
+        ):
+            yield from sink.load(model_gen)

--- a/mex/common/sinks/ndjson.py
+++ b/mex/common/sinks/ndjson.py
@@ -54,11 +54,12 @@ class NdjsonSink(BaseSink):
                         writer = open(file_name, "a+", encoding="utf-8")  # noqa: SIM115
                         file_handles[class_name] = fh = stack.enter_context(writer)
                         logger.info(
-                            "NdjsonSink - writing %s to file %s",
+                            "%s - writing %s to file %s",
+                            type(self).__name__,
                             class_name,
                             file_name.as_posix(),
                         )
                     fh.write(f"{json.dumps(model, sort_keys=True, cls=MExEncoder)}\n")
                     total_count += 1
                     yield model.identifier
-                logger.info("NdjsonSink - written %s models", total_count)
+                logger.info("%s - written %s models", type(self).__name__, total_count)

--- a/mex/common/sinks/ndjson.py
+++ b/mex/common/sinks/ndjson.py
@@ -4,45 +4,61 @@ from contextlib import ExitStack
 from pathlib import Path
 from typing import IO, Any
 
-from mex.common.logging import logger, watch
+from mex.common.logging import logger
 from mex.common.models import AnyExtractedModel
 from mex.common.settings import BaseSettings
+from mex.common.sinks.base import BaseSink
 from mex.common.transform import MExEncoder
 from mex.common.types import AnyExtractedIdentifier
+from mex.common.utils import grouper
 
 
-@watch
-def write_ndjson(
-    models: Iterable[AnyExtractedModel],
-) -> Generator[AnyExtractedIdentifier, None, None]:
-    """Write the incoming models into a new-line delimited JSON file.
+class NdjsonSink(BaseSink):
+    """Sink to load models into new-line delimited JSON files."""
 
-    Args:
-        models: Iterable of extracted models to write
+    CHUNK_SIZE = 100
+    _work_dir: Path
 
-    Settings:
-        work_dir: Path to store the NDJSON files in
+    def __init__(self) -> None:
+        """Instantiate the multi sink singleton."""
+        settings = BaseSettings.get()
+        self._work_dir = Path(settings.work_dir)
 
-    Returns:
-        Generator for identifiers of written models
-    """
-    file_handles: dict[str, IO[Any]] = {}
-    settings = BaseSettings.get()
-    with ExitStack() as stack:
-        for model in models:
-            class_name = model.__class__.__name__
-            try:
-                handle = file_handles[class_name]
-            except KeyError:
-                file_name = Path(settings.work_dir, f"{class_name}.ndjson")
-                writer = open(file_name, "a+", encoding="utf-8")  # noqa: SIM115
-                file_handles[class_name] = handle = stack.enter_context(writer)
-                logger.info(
-                    "write_ndjson - writing %s to file %s",
-                    class_name,
-                    file_name.as_posix(),
-                )
+    def close(self) -> None:
+        """Nothing to close, since load already closes all file handles."""
 
-            json.dump(model, handle, sort_keys=True, cls=MExEncoder)
-            handle.write("\n")
-            yield model.identifier
+    def load(
+        self,
+        models: Iterable[AnyExtractedModel],
+    ) -> Generator[AnyExtractedIdentifier, None, None]:
+        """Write the incoming models into a new-line delimited JSON file.
+
+        Args:
+            models: Iterable of extracted models to write
+
+        Returns:
+            Generator for identifiers of written models
+        """
+        file_handles: dict[str, IO[Any]] = {}
+        total_count = 0
+        with ExitStack() as stack:
+            for chunk in grouper(self.CHUNK_SIZE, models):
+                for model in chunk:
+                    if model is None:
+                        continue
+                    class_name = model.__class__.__name__
+                    try:
+                        fh = file_handles[class_name]
+                    except KeyError:
+                        file_name = self._work_dir / f"{class_name}.ndjson"
+                        writer = open(file_name, "a+", encoding="utf-8")  # noqa: SIM115
+                        file_handles[class_name] = fh = stack.enter_context(writer)
+                        logger.info(
+                            "NdjsonSink - writing %s to file %s",
+                            class_name,
+                            file_name.as_posix(),
+                        )
+                    fh.write(f"{json.dumps(model, sort_keys=True, cls=MExEncoder)}\n")
+                    total_count += 1
+                    yield model.identifier
+                logger.info("NdjsonSink - written %s models", total_count)

--- a/mex/common/sinks/ndjson.py
+++ b/mex/common/sinks/ndjson.py
@@ -31,7 +31,7 @@ class NdjsonSink(BaseSink):
         self,
         models: Iterable[AnyExtractedModel],
     ) -> Generator[AnyExtractedIdentifier, None, None]:
-        """Write the incoming models into a new-line delimited JSON file.
+        """Write models into a new-line delimited JSON file.
 
         Args:
             models: Iterable of extracted models to write

--- a/mex/common/sinks/registry.py
+++ b/mex/common/sinks/registry.py
@@ -1,0 +1,46 @@
+from typing import TYPE_CHECKING, Final
+
+from mex.common.sinks.backend_api import BackendApiSink
+from mex.common.sinks.ndjson import NdjsonSink
+from mex.common.types import Sink
+
+if TYPE_CHECKING:
+    from mex.common.sinks.base import BaseSink
+
+_SINK_REGISTRY: Final[dict[Sink, type["BaseSink"]]] = {}
+
+
+def register_sink(key: Sink, sink_cls: type["BaseSink"]) -> None:
+    """Register an implementation of a sink function to a settings key.
+
+    Args:
+        key: Possible value of `BaseSettings.sink`
+        sink_cls: Implementation of the abstract sink class
+
+    Raises:
+        RuntimeError: When the `key` is already registered
+    """
+    if key in _SINK_REGISTRY:
+        msg = f"Already registered sink function: {key}"
+        raise RuntimeError(msg)
+    _SINK_REGISTRY[key] = sink_cls
+
+
+def get_sink() -> "BaseSink":
+    """Get a sink function that serves all configured `sink` destinations.
+
+    Raises:
+        RuntimeError: When the configured sink is not registered
+
+    Returns:
+        A function that pours the models into all configured sinks
+    """
+    # break import cycle, sigh
+    from mex.common.sinks.base import MultiSink
+
+    return MultiSink.get()
+
+
+# register the default providers shipped with mex-common
+register_sink(Sink.BACKEND, BackendApiSink)
+register_sink(Sink.NDJSON, NdjsonSink)

--- a/mex/common/sinks/registry.py
+++ b/mex/common/sinks/registry.py
@@ -41,7 +41,7 @@ class _MultiSink(BaseSink):
     ) -> Generator[Identifier, None, None]:
         """Load models to multiple sinks simultaneously."""
         for sink, model_gen in zip(
-            self._sinks, tee(models, len(self._sinks)), strict=False
+            self._sinks, tee(models, len(self._sinks)), strict=True
         ):
             yield from sink.load(model_gen)
 

--- a/tests/backend_api/test_connector.py
+++ b/tests/backend_api/test_connector.py
@@ -40,7 +40,7 @@ def test_post_extracted_items_mocked(
             "Accept": "application/json",
             "User-Agent": "rki/mex",
         },
-        timeout=10,
+        timeout=BackendApiConnector.INGEST_TIMEOUT,
         data=Joker(),
     )
     assert (

--- a/tests/sinks/test_backend_api.py
+++ b/tests/sinks/test_backend_api.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, Mock
 
 from pytest import MonkeyPatch
 
+from mex.common.backend_api.connector import BackendApiConnector
 from mex.common.backend_api.models import IdentifiersResponse
 from mex.common.models import ExtractedPerson
 from mex.common.sinks.backend_api import BackendApiSink
@@ -10,14 +11,16 @@ from mex.common.sinks.backend_api import BackendApiSink
 def test_sink_load_mocked(
     extracted_person: ExtractedPerson, monkeypatch: MonkeyPatch
 ) -> None:
-    def __init__(self: BackendApiSink) -> None:
+    def __init__(self: BackendApiConnector) -> None:
         self.session = MagicMock()
 
-    monkeypatch.setattr(BackendApiSink, "__init__", __init__)
+    monkeypatch.setattr(BackendApiConnector, "__init__", __init__)
 
     response = IdentifiersResponse(identifiers=[extracted_person.identifier])
     post_extracted_items = Mock(return_value=response)
-    monkeypatch.setattr(BackendApiSink, "post_extracted_items", post_extracted_items)
+    monkeypatch.setattr(
+        BackendApiConnector, "post_extracted_items", post_extracted_items
+    )
 
     sink = BackendApiSink.get()
     model_ids = list(sink.load([extracted_person]))

--- a/tests/sinks/test_backend_api.py
+++ b/tests/sinks/test_backend_api.py
@@ -2,26 +2,24 @@ from unittest.mock import MagicMock, Mock
 
 from pytest import MonkeyPatch
 
-from mex.common.backend_api.connector import BackendApiConnector
 from mex.common.backend_api.models import IdentifiersResponse
 from mex.common.models import ExtractedPerson
-from mex.common.sinks.backend_api import post_to_backend_api
+from mex.common.sinks.backend_api import BackendApiSink
 
 
-def test_post_to_backend_api_mocked(
+def test_sink_load_mocked(
     extracted_person: ExtractedPerson, monkeypatch: MonkeyPatch
 ) -> None:
-    def __init__(self: BackendApiConnector) -> None:
+    def __init__(self: BackendApiSink) -> None:
         self.session = MagicMock()
 
-    monkeypatch.setattr(BackendApiConnector, "__init__", __init__)
+    monkeypatch.setattr(BackendApiSink, "__init__", __init__)
 
     response = IdentifiersResponse(identifiers=[extracted_person.identifier])
     post_extracted_items = Mock(return_value=response)
-    monkeypatch.setattr(
-        BackendApiConnector, "post_extracted_items", post_extracted_items
-    )
+    monkeypatch.setattr(BackendApiSink, "post_extracted_items", post_extracted_items)
 
-    model_ids = list(post_to_backend_api([extracted_person]))
+    sink = BackendApiSink.get()
+    model_ids = list(sink.load([extracted_person]))
     assert model_ids == response.identifiers
     post_extracted_items.assert_called_once_with([extracted_person])

--- a/tests/sinks/test_ndjson.py
+++ b/tests/sinks/test_ndjson.py
@@ -5,7 +5,7 @@ from pydantic import UUID4
 
 from mex.common.models import ExtractedData
 from mex.common.settings import BaseSettings
-from mex.common.sinks.ndjson import write_ndjson
+from mex.common.sinks.ndjson import NdjsonSink
 from mex.common.types import Identifier, TemporalEntity
 
 
@@ -21,7 +21,7 @@ class ExtractedThing(ExtractedData):
     ts_attr: TemporalEntity | None = None
 
 
-def test_write_ndjson() -> None:
+def test_sink_load() -> None:
     settings = BaseSettings.get()
 
     test_models = [
@@ -37,7 +37,8 @@ def test_write_ndjson() -> None:
         ),
     ]
 
-    ids = list(write_ndjson(test_models))
+    sink = NdjsonSink.get()
+    ids = list(sink.load(test_models))
     assert len(ids)
 
     with open(settings.work_dir / "ExtractedThing.ndjson") as handle:


### PR DESCRIPTION
### PR Context

- sibling PR to https://github.com/robert-koch-institut/mex-common/pull/366

### Added

- add a sink registry with `register_sink` and `get_sink` functions
- add a `MultiSink` implementation, akin to `mex.extractors.load`

### Changes

- BREAKING: convert post_to_backend_api to BackendApiSink
- BREAKING: convert write_ndjson to NdjsonSink
