### PR TITLE
feature/skip None values when merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- skip None values when merging extracted and rule items
+
 ### Security
 
 ## [0.47.0] - 2025-01-23

--- a/mex/common/merged/main.py
+++ b/mex/common/merged/main.py
@@ -153,4 +153,5 @@ def create_merged_item(
     try:
         return cls.model_validate(merged_dict)
     except ValidationError as error:
-        raise MergingError from error
+        msg = "Could not validate merged model."
+        raise MergingError(msg) from error

--- a/mex/common/merged/utils.py
+++ b/mex/common/merged/utils.py
@@ -4,20 +4,28 @@ from typing import TypeVar
 T = TypeVar("T")
 
 
-def extend_list_in_dict(dict_: dict[str, list[T]], key: str, item: list[T] | T) -> None:
+def extend_list_in_dict(
+    dict_: dict[str, list[T]], key: str, item: list[T] | T | None
+) -> None:
     """Extend a list in a dict for a given key with the given unique item(s)."""
     list_ = dict_.setdefault(key, [])
-    if not isinstance(item, list):
+    if item is None:
+        item = []
+    elif not isinstance(item, list):
         item = [item]
     for mergeable in item:
         if mergeable not in list_:
             list_.append(mergeable)
 
 
-def prune_list_in_dict(dict_: dict[str, list[T]], key: str, item: list[T] | T) -> None:
+def prune_list_in_dict(
+    dict_: dict[str, list[T]], key: str, item: list[T] | T | None
+) -> None:
     """Safely remove item(s) from a list in a dict for the given key."""
     list_ = dict_.setdefault(key, [])
-    if not isinstance(item, list):
+    if item is None:
+        item = []
+    elif not isinstance(item, list):
         item = [item]
     for removable in item:
         with contextlib.suppress(ValueError):

--- a/tests/merged/test_utils.py
+++ b/tests/merged/test_utils.py
@@ -16,14 +16,39 @@ def test_extend_list_in_dict() -> None:
         "new-key": ["single-value"],
     }
 
+    extend_list_in_dict(dict_, "existing-key", None)
+    assert dict_ == {
+        "existing-key": ["already-here", "another-value"],
+        "new-key": ["single-value"],
+    }
+
+    extend_list_in_dict(dict_, "another-key", None)
+    assert dict_ == {
+        "existing-key": ["already-here", "another-value"],
+        "new-key": ["single-value"],
+        "another-key": [],
+    }
+
 
 def test_prune_list_in_dict() -> None:
     dict_ = {
         "existing-key": ["leave-me-alone"],
-        "prune-me": ["42", "foo"],
+        "prune-me": ["1", "2", "42", "foo"],
+    }
+
+    prune_list_in_dict(dict_, "prune-me", ["1", "2"])
+    assert dict_ == {
+        "existing-key": ["leave-me-alone"],
+        "prune-me": ["foo", "42"],
     }
 
     prune_list_in_dict(dict_, "prune-me", "foo")
+    assert dict_ == {
+        "existing-key": ["leave-me-alone"],
+        "prune-me": ["42"],
+    }
+
+    prune_list_in_dict(dict_, "prune-me", None)
     assert dict_ == {
         "existing-key": ["leave-me-alone"],
         "prune-me": ["42"],

--- a/tests/merged/test_utils.py
+++ b/tests/merged/test_utils.py
@@ -39,7 +39,7 @@ def test_prune_list_in_dict() -> None:
     prune_list_in_dict(dict_, "prune-me", ["1", "2"])
     assert dict_ == {
         "existing-key": ["leave-me-alone"],
-        "prune-me": ["foo", "42"],
+        "prune-me": ["42", "foo"],
     }
 
     prune_list_in_dict(dict_, "prune-me", "foo")


### PR DESCRIPTION
# PR Context
- this broke the merging of optional fields, e.g. on ExtractedResources

# Fixed
- skip None values when merging extracted and rule items
