### PR TITLE
feature/mx 1744 expand accepted models of sink to rule items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changes
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.48.0] - 2025-01-28
+
+### Added
+
 - add a sink registry with `register_sink` and `get_sink` functions
 - add a multi-sink implementation, akin to `mex.extractors.load`
 
@@ -22,14 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - allow backend and graph as identity provider setting to simplify setting subclasses,
   even though graph is not implemented in mex-common
 - BREAKING: make backend api connector response models generic, to keep DRY
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
 
 ## [0.47.1] - 2025-01-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- BREAKING: move ItemsContainer and PaginatedItemsContainer to mex.common.models
+- BREAKING: replace post_extracted_items with ingest and allow AnyRuleSetResponses
+- allow AnyRuleSetResponses as arguments to sinks
+- BREAKING: sinks now yield the models they loaded, instead of just their identifiers
+
 ### Deprecated
 
 ### Removed

--- a/mex/common/backend_api/connector.py
+++ b/mex/common/backend_api/connector.py
@@ -41,10 +41,8 @@ class BackendApiConnector(HTTPConnector):
 
     def ingest(
         self,
-        models_or_rule_sets: list[
-            AnyExtractedModel | AnyRuleSetRequest | AnyRuleSetResponse
-        ],
-    ) -> list[AnyExtractedModel | AnyRuleSetRequest | AnyRuleSetResponse]:
+        models_or_rule_sets: list[AnyExtractedModel | AnyRuleSetResponse],
+    ) -> list[AnyExtractedModel | AnyRuleSetResponse]:
         """Post extracted models or rule-sets to the backend in bulk.
 
         Args:
@@ -59,13 +57,13 @@ class BackendApiConnector(HTTPConnector):
         response = self.request(
             method="POST",
             endpoint="ingest",
-            payload=ItemsContainer[
-                AnyExtractedModel | AnyRuleSetRequest | AnyRuleSetResponse
-            ](items=models_or_rule_sets),
+            payload=ItemsContainer[AnyExtractedModel | AnyRuleSetResponse](
+                items=models_or_rule_sets
+            ),
             timeout=self.INGEST_TIMEOUT,
         )
         return (
-            ItemsContainer[AnyExtractedModel | AnyRuleSetRequest | AnyRuleSetResponse]
+            ItemsContainer[AnyExtractedModel | AnyRuleSetResponse]
             .model_validate(response)
             .items
         )

--- a/mex/common/backend_api/connector.py
+++ b/mex/common/backend_api/connector.py
@@ -3,9 +3,7 @@ from urllib.parse import urljoin
 from requests.exceptions import HTTPError
 
 from mex.common.backend_api.models import (
-    ItemsContainer,
     MergedModelTypeAdapter,
-    PaginatedItemsContainer,
     RuleSetResponseTypeAdapter,
 )
 from mex.common.connector import HTTPConnector
@@ -15,6 +13,8 @@ from mex.common.models import (
     AnyPreviewModel,
     AnyRuleSetRequest,
     AnyRuleSetResponse,
+    ItemsContainer,
+    PaginatedItemsContainer,
 )
 from mex.common.settings import BaseSettings
 

--- a/mex/common/backend_api/models.py
+++ b/mex/common/backend_api/models.py
@@ -1,24 +1,8 @@
-from typing import Annotated, Generic, TypeVar
+from typing import Annotated
 
 from pydantic import Field, TypeAdapter
 
-from mex.common.models import AnyMergedModel, AnyRuleSetResponse, BaseModel
-
-T = TypeVar("T")
-
-
-class ItemsContainer(BaseModel, Generic[T]):
-    """Generic container that contains items."""
-
-    items: list[T]
-
-
-class PaginatedItemsContainer(BaseModel, Generic[T]):
-    """Generic container that contains items and has a total item count."""
-
-    items: list[T]
-    total: int
-
+from mex.common.models import AnyMergedModel, AnyRuleSetResponse
 
 MergedModelTypeAdapter: TypeAdapter[AnyMergedModel] = TypeAdapter(
     Annotated[AnyMergedModel, Field(discriminator="entityType")]

--- a/mex/common/backend_api/models.py
+++ b/mex/common/backend_api/models.py
@@ -3,7 +3,6 @@ from typing import Annotated, Generic, TypeVar
 from pydantic import Field, TypeAdapter
 
 from mex.common.models import AnyMergedModel, AnyRuleSetResponse, BaseModel
-from mex.common.types import Identifier
 
 T = TypeVar("T")
 
@@ -19,12 +18,6 @@ class PaginatedItemsContainer(BaseModel, Generic[T]):
 
     items: list[T]
     total: int
-
-
-class IdentifiersResponse(BaseModel):
-    """Response models for a list of identifiers."""
-
-    identifiers: list[Identifier]
 
 
 MergedModelTypeAdapter: TypeAdapter[AnyMergedModel] = TypeAdapter(

--- a/mex/common/identity/backend_api.py
+++ b/mex/common/identity/backend_api.py
@@ -1,9 +1,9 @@
 from functools import cache
 
 from mex.common.backend_api.connector import BackendApiConnector
-from mex.common.backend_api.models import ItemsContainer
 from mex.common.identity.base import BaseProvider
 from mex.common.identity.models import Identity
+from mex.common.models import ItemsContainer
 from mex.common.types import Identifier, MergedPrimarySourceIdentifier
 
 

--- a/mex/common/models/__init__.py
+++ b/mex/common/models/__init__.py
@@ -94,6 +94,10 @@ from mex.common.models.activity import (
     PreviewActivity,
     SubtractiveActivity,
 )
+from mex.common.models.base.container import (
+    ItemsContainer,
+    PaginatedItemsContainer,
+)
 from mex.common.models.base.extracted_data import ExtractedData
 from mex.common.models.base.filter import generate_entity_filter_schema
 from mex.common.models.base.mapping import generate_mapping_schema
@@ -311,6 +315,7 @@ __all__ = (
     "ExtractedResource",
     "ExtractedVariable",
     "ExtractedVariableGroup",
+    "ItemsContainer",
     "MergedAccessPlatform",
     "MergedActivity",
     "MergedBibliographicResource",
@@ -329,6 +334,7 @@ __all__ = (
     "OrganizationRuleSetResponse",
     "OrganizationalUnitRuleSetRequest",
     "OrganizationalUnitRuleSetResponse",
+    "PaginatedItemsContainer",
     "PersonRuleSetRequest",
     "PersonRuleSetResponse",
     "PreventiveAccessPlatform",

--- a/mex/common/models/base/container.py
+++ b/mex/common/models/base/container.py
@@ -1,6 +1,6 @@
 from typing import Generic, TypeVar
 
-from mex.common.models import BaseModel
+from pydantic import BaseModel
 
 T = TypeVar("T")
 

--- a/mex/common/models/base/container.py
+++ b/mex/common/models/base/container.py
@@ -1,0 +1,18 @@
+from typing import Generic, TypeVar
+
+from mex.common.models import BaseModel
+
+T = TypeVar("T")
+
+
+class ItemsContainer(BaseModel, Generic[T]):
+    """Generic container that contains items."""
+
+    items: list[T]
+
+
+class PaginatedItemsContainer(BaseModel, Generic[T]):
+    """Generic container that contains items and has a total item count."""
+
+    items: list[T]
+    total: int

--- a/mex/common/sinks/backend_api.py
+++ b/mex/common/sinks/backend_api.py
@@ -1,11 +1,9 @@
 from collections.abc import Generator, Iterable
-from typing import cast
 
 from mex.common.backend_api.connector import BackendApiConnector
 from mex.common.logging import logger
-from mex.common.models import AnyExtractedModel
+from mex.common.models import AnyExtractedModel, AnyRuleSetRequest, AnyRuleSetResponse
 from mex.common.sinks.base import BaseSink
-from mex.common.types import AnyExtractedIdentifier
 from mex.common.utils import grouper
 
 
@@ -16,21 +14,25 @@ class BackendApiSink(BaseSink):
 
     def load(
         self,
-        models: Iterable[AnyExtractedModel],
-    ) -> Generator[AnyExtractedIdentifier, None, None]:
-        """Load models to the Backend API using bulk insertion.
+        models_or_rule_sets: Iterable[
+            AnyExtractedModel | AnyRuleSetRequest | AnyRuleSetResponse
+        ],
+    ) -> Generator[
+        AnyExtractedModel | AnyRuleSetRequest | AnyRuleSetResponse, None, None
+    ]:
+        """Load extracted models or rule-sets to the Backend API using bulk insertion.
 
         Args:
-            models: Iterable of extracted models
+            models_or_rule_sets: Iterable of extracted models or rule-sets
 
         Returns:
-            Generator for identifiers of posted models
+            Generator for posted models
         """
         total_count = 0
         connector = BackendApiConnector.get()
-        for chunk in grouper(self.CHUNK_SIZE, models):
+        for chunk in grouper(self.CHUNK_SIZE, models_or_rule_sets):
             model_list = [model for model in chunk if model is not None]
-            response = connector.post_extracted_items(model_list)
+            connector.ingest(model_list)
             total_count += len(model_list)
-            yield from cast(list[AnyExtractedIdentifier], response.identifiers)
+            yield from model_list
             logger.info("%s - written %s models", type(self).__name__, total_count)

--- a/mex/common/sinks/backend_api.py
+++ b/mex/common/sinks/backend_api.py
@@ -2,7 +2,7 @@ from collections.abc import Generator, Iterable
 
 from mex.common.backend_api.connector import BackendApiConnector
 from mex.common.logging import logger
-from mex.common.models import AnyExtractedModel, AnyRuleSetRequest, AnyRuleSetResponse
+from mex.common.models import AnyExtractedModel, AnyRuleSetResponse
 from mex.common.sinks.base import BaseSink
 from mex.common.utils import grouper
 
@@ -14,12 +14,8 @@ class BackendApiSink(BaseSink):
 
     def load(
         self,
-        models_or_rule_sets: Iterable[
-            AnyExtractedModel | AnyRuleSetRequest | AnyRuleSetResponse
-        ],
-    ) -> Generator[
-        AnyExtractedModel | AnyRuleSetRequest | AnyRuleSetResponse, None, None
-    ]:
+        models_or_rule_sets: Iterable[AnyExtractedModel | AnyRuleSetResponse],
+    ) -> Generator[AnyExtractedModel | AnyRuleSetResponse, None, None]:
         """Load extracted models or rule-sets to the Backend API using bulk insertion.
 
         Args:

--- a/mex/common/sinks/base.py
+++ b/mex/common/sinks/base.py
@@ -1,9 +1,8 @@
 from abc import abstractmethod
-from collections.abc import Iterable
+from collections.abc import Generator, Iterable
 
 from mex.common.connector import BaseConnector
-from mex.common.models import AnyExtractedModel
-from mex.common.types import Identifier
+from mex.common.models import AnyExtractedModel, AnyRuleSetRequest, AnyRuleSetResponse
 
 
 class BaseSink(BaseConnector):
@@ -17,7 +16,12 @@ class BaseSink(BaseConnector):
 
     @abstractmethod
     def load(
-        self, models: Iterable[AnyExtractedModel]
-    ) -> Iterable[Identifier]:  # pragma: no cover
-        """Iteratively load models to a destination and yield their identifiers."""
+        self,
+        models_or_rule_sets: Iterable[
+            AnyExtractedModel | AnyRuleSetRequest | AnyRuleSetResponse
+        ],
+    ) -> Generator[
+        AnyExtractedModel | AnyRuleSetRequest | AnyRuleSetResponse, None, None
+    ]:  # pragma: no cover
+        """Load extracted models or rule-sets to a destination and yield them."""
         ...

--- a/mex/common/sinks/base.py
+++ b/mex/common/sinks/base.py
@@ -2,7 +2,7 @@ from abc import abstractmethod
 from collections.abc import Generator, Iterable
 
 from mex.common.connector import BaseConnector
-from mex.common.models import AnyExtractedModel, AnyRuleSetRequest, AnyRuleSetResponse
+from mex.common.models import AnyExtractedModel, AnyRuleSetResponse
 
 
 class BaseSink(BaseConnector):
@@ -17,11 +17,9 @@ class BaseSink(BaseConnector):
     @abstractmethod
     def load(
         self,
-        models_or_rule_sets: Iterable[
-            AnyExtractedModel | AnyRuleSetRequest | AnyRuleSetResponse
-        ],
+        models_or_rule_sets: Iterable[AnyExtractedModel | AnyRuleSetResponse],
     ) -> Generator[
-        AnyExtractedModel | AnyRuleSetRequest | AnyRuleSetResponse, None, None
+        AnyExtractedModel | AnyRuleSetResponse, None, None
     ]:  # pragma: no cover
         """Load extracted models or rule-sets to a destination and yield them."""
         ...

--- a/mex/common/sinks/ndjson.py
+++ b/mex/common/sinks/ndjson.py
@@ -2,10 +2,10 @@ import json
 from collections.abc import Generator, Iterable
 from contextlib import ExitStack
 from pathlib import Path
-from typing import IO, Any
+from typing import IO, Any, overload
 
 from mex.common.logging import logger
-from mex.common.models import AnyExtractedModel
+from mex.common.models import AnyExtractedModel, AnyRuleModel
 from mex.common.settings import BaseSettings
 from mex.common.sinks.base import BaseSink
 from mex.common.transform import MExEncoder
@@ -27,26 +27,38 @@ class NdjsonSink(BaseSink):
     def close(self) -> None:
         """Nothing to close, since load already closes all file handles."""
 
+    @overload
     def load(
         self,
-        models: Iterable[AnyExtractedModel],
-    ) -> Generator[AnyExtractedIdentifier, None, None]:
-        """Write models into a new-line delimited JSON file.
+        models_or_rules: Iterable[AnyExtractedModel],
+    ) -> Generator[AnyExtractedIdentifier, None, None]: ...
+
+    @overload
+    def load(
+        self,
+        models_or_rules: Iterable[AnyRuleModel],
+    ) -> None: ...
+
+    def load(
+        self,
+        models_or_rules: Iterable[AnyExtractedModel] | Iterable[AnyRuleModel],
+    ) -> Generator[AnyExtractedIdentifier, None, None] | None:
+        """Write models or rules into a new-line delimited JSON file.
 
         Args:
-            models: Iterable of extracted models to write
+          models_or_rules: Iterable of extracted models or rules to write
 
         Returns:
-            Generator for identifiers of written models
+          Generator for identifiers of written models or None if rules.
         """
         file_handles: dict[str, IO[Any]] = {}
         total_count = 0
         with ExitStack() as stack:
-            for chunk in grouper(self.CHUNK_SIZE, models):
-                for model in chunk:
-                    if model is None:
+            for chunk in grouper(self.CHUNK_SIZE, models_or_rules):
+                for model_or_rule in chunk:
+                    if model_or_rule is None:
                         continue
-                    class_name = model.__class__.__name__
+                    class_name = model_or_rule.__class__.__name__
                     try:
                         fh = file_handles[class_name]
                     except KeyError:
@@ -59,7 +71,11 @@ class NdjsonSink(BaseSink):
                             class_name,
                             file_name.as_posix(),
                         )
-                    fh.write(f"{json.dumps(model, sort_keys=True, cls=MExEncoder)}\n")
+                    fh.write(
+                        f"{json.dumps(model_or_rule, sort_keys=True, cls=MExEncoder)}\n"
+                    )
                     total_count += 1
-                    yield model.identifier
-                logger.info("%s - written %s models", type(self).__name__, total_count)
+                    if hasattr(model_or_rule, "identifier"):
+                        yield model_or_rule.identifier
+                logger.info("%s - written %s items", type(self).__name__, total_count)
+        return None

--- a/mex/common/sinks/ndjson.py
+++ b/mex/common/sinks/ndjson.py
@@ -2,14 +2,17 @@ import json
 from collections.abc import Generator, Iterable
 from contextlib import ExitStack
 from pathlib import Path
-from typing import IO, Any, overload
+from typing import IO, Any
 
 from mex.common.logging import logger
-from mex.common.models import AnyExtractedModel, AnyRuleModel
+from mex.common.models import (
+    AnyExtractedModel,
+    AnyRuleSetRequest,
+    AnyRuleSetResponse,
+)
 from mex.common.settings import BaseSettings
 from mex.common.sinks.base import BaseSink
 from mex.common.transform import MExEncoder
-from mex.common.types import AnyExtractedIdentifier
 from mex.common.utils import grouper
 
 
@@ -27,38 +30,30 @@ class NdjsonSink(BaseSink):
     def close(self) -> None:
         """Nothing to close, since load already closes all file handles."""
 
-    @overload
     def load(
         self,
-        models_or_rules: Iterable[AnyExtractedModel],
-    ) -> Generator[AnyExtractedIdentifier, None, None]: ...
-
-    @overload
-    def load(
-        self,
-        models_or_rules: Iterable[AnyRuleModel],
-    ) -> None: ...
-
-    def load(
-        self,
-        models_or_rules: Iterable[AnyExtractedModel] | Iterable[AnyRuleModel],
-    ) -> Generator[AnyExtractedIdentifier, None, None] | None:
-        """Write models or rules into a new-line delimited JSON file.
+        models_or_rule_sets: Iterable[
+            AnyExtractedModel | AnyRuleSetRequest | AnyRuleSetResponse
+        ],
+    ) -> Generator[
+        AnyExtractedModel | AnyRuleSetRequest | AnyRuleSetResponse, None, None
+    ]:
+        """Write models or rule-sets into a new-line delimited JSON file.
 
         Args:
-          models_or_rules: Iterable of extracted models or rules to write
+            models_or_rule_sets: Extracted models, rule-set requests or responses
 
         Returns:
-          Generator for identifiers of written models or None if rules.
+            Generator for the loaded models or rules.
         """
         file_handles: dict[str, IO[Any]] = {}
         total_count = 0
         with ExitStack() as stack:
-            for chunk in grouper(self.CHUNK_SIZE, models_or_rules):
-                for model_or_rule in chunk:
-                    if model_or_rule is None:
+            for chunk in grouper(self.CHUNK_SIZE, models_or_rule_sets):
+                for model_or_rule_set in chunk:
+                    if model_or_rule_set is None:
                         continue
-                    class_name = model_or_rule.__class__.__name__
+                    class_name = model_or_rule_set.__class__.__name__
                     try:
                         fh = file_handles[class_name]
                     except KeyError:
@@ -71,11 +66,10 @@ class NdjsonSink(BaseSink):
                             class_name,
                             file_name.as_posix(),
                         )
-                    fh.write(
-                        f"{json.dumps(model_or_rule, sort_keys=True, cls=MExEncoder)}\n"
+                    dumped_json = json.dumps(
+                        model_or_rule_set, sort_keys=True, cls=MExEncoder
                     )
+                    fh.write(f"{dumped_json}\n")
                     total_count += 1
-                    if hasattr(model_or_rule, "identifier"):
-                        yield model_or_rule.identifier
+                    yield model_or_rule_set
                 logger.info("%s - written %s items", type(self).__name__, total_count)
-        return None

--- a/mex/common/sinks/registry.py
+++ b/mex/common/sinks/registry.py
@@ -2,12 +2,12 @@ from collections.abc import Generator, Iterable
 from itertools import tee
 from typing import Final
 
-from mex.common.models import AnyExtractedModel
+from mex.common.models import AnyExtractedModel, AnyRuleSetRequest, AnyRuleSetResponse
 from mex.common.settings import BaseSettings
 from mex.common.sinks.backend_api import BackendApiSink
 from mex.common.sinks.base import BaseSink
 from mex.common.sinks.ndjson import NdjsonSink
-from mex.common.types import Identifier, Sink
+from mex.common.types import Sink
 
 _SINK_REGISTRY: Final[dict[Sink, type["BaseSink"]]] = {}
 
@@ -37,11 +37,15 @@ class _MultiSink(BaseSink):
 
     def load(
         self,
-        models: Iterable[AnyExtractedModel],
-    ) -> Generator[Identifier, None, None]:
-        """Load models to multiple sinks simultaneously."""
+        models_or_rule_sets: Iterable[
+            AnyExtractedModel | AnyRuleSetRequest | AnyRuleSetResponse
+        ],
+    ) -> Generator[
+        AnyExtractedModel | AnyRuleSetRequest | AnyRuleSetResponse, None, None
+    ]:
+        """Load models or rule-sets to multiple sinks simultaneously."""
         for sink, model_gen in zip(
-            self._sinks, tee(models, len(self._sinks)), strict=True
+            self._sinks, tee(models_or_rule_sets, len(self._sinks)), strict=True
         ):
             yield from sink.load(model_gen)
 

--- a/mex/common/sinks/registry.py
+++ b/mex/common/sinks/registry.py
@@ -2,7 +2,7 @@ from collections.abc import Generator, Iterable
 from itertools import tee
 from typing import Final
 
-from mex.common.models import AnyExtractedModel, AnyRuleSetRequest, AnyRuleSetResponse
+from mex.common.models import AnyExtractedModel, AnyRuleSetResponse
 from mex.common.settings import BaseSettings
 from mex.common.sinks.backend_api import BackendApiSink
 from mex.common.sinks.base import BaseSink
@@ -37,12 +37,8 @@ class _MultiSink(BaseSink):
 
     def load(
         self,
-        models_or_rule_sets: Iterable[
-            AnyExtractedModel | AnyRuleSetRequest | AnyRuleSetResponse
-        ],
-    ) -> Generator[
-        AnyExtractedModel | AnyRuleSetRequest | AnyRuleSetResponse, None, None
-    ]:
+        models_or_rule_sets: Iterable[AnyExtractedModel | AnyRuleSetResponse],
+    ) -> Generator[AnyExtractedModel | AnyRuleSetResponse, None, None]:
         """Load models or rule-sets to multiple sinks simultaneously."""
         for sink, model_gen in zip(
             self._sinks, tee(models_or_rule_sets, len(self._sinks)), strict=True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mex-common"
-version = "0.47.1"
+version = "0.48.0"
 description = "Common library for MEx python projects."
 authors = [{ name = "MEx Team", email = "mex@rki.de" }]
 readme = { file = "README.md", content-type = "text/markdown" }

--- a/tests/backend_api/test_connector.py
+++ b/tests/backend_api/test_connector.py
@@ -5,12 +5,13 @@ import pytest
 from requests.exceptions import HTTPError
 
 from mex.common.backend_api.connector import BackendApiConnector
-from mex.common.backend_api.models import ItemsContainer, PaginatedItemsContainer
 from mex.common.models import (
     AnyExtractedModel,
     AnyPreviewModel,
     ExtractedPerson,
+    ItemsContainer,
     MergedPerson,
+    PaginatedItemsContainer,
     PersonRuleSetRequest,
     PersonRuleSetResponse,
     PreviewPerson,

--- a/tests/backend_api/test_connector.py
+++ b/tests/backend_api/test_connector.py
@@ -24,16 +24,16 @@ def test_set_authentication_mocked() -> None:
     assert connector.session.headers["X-API-Key"] == "dummy_write_key"
 
 
-def test_post_extracted_items_mocked(
+def test_ingest_mocked(
     mocked_backend: MagicMock, extracted_person: ExtractedPerson
 ) -> None:
-    mocked_return = {"identifiers": [extracted_person.identifier]}
+    mocked_return = {"items": [extracted_person]}
     mocked_backend.return_value.json.return_value = mocked_return
 
     connector = BackendApiConnector.get()
-    response = connector.post_extracted_items([extracted_person])
+    response = connector.ingest([extracted_person])
 
-    assert response.identifiers == [extracted_person.identifier]
+    assert response == [extracted_person]
     assert mocked_backend.call_args == call(
         "POST",
         "http://localhost:8080/v0/ingest",

--- a/tests/sinks/test_backend_api.py
+++ b/tests/sinks/test_backend_api.py
@@ -3,8 +3,7 @@ from unittest.mock import MagicMock, Mock
 from pytest import MonkeyPatch
 
 from mex.common.backend_api.connector import BackendApiConnector
-from mex.common.backend_api.models import ItemsContainer
-from mex.common.models import ExtractedPerson
+from mex.common.models import ExtractedPerson, ItemsContainer
 from mex.common.sinks.backend_api import BackendApiSink
 
 

--- a/tests/sinks/test_backend_api.py
+++ b/tests/sinks/test_backend_api.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, Mock
 from pytest import MonkeyPatch
 
 from mex.common.backend_api.connector import BackendApiConnector
-from mex.common.backend_api.models import IdentifiersResponse
+from mex.common.backend_api.models import ItemsContainer
 from mex.common.models import ExtractedPerson
 from mex.common.sinks.backend_api import BackendApiSink
 
@@ -16,13 +16,11 @@ def test_sink_load_mocked(
 
     monkeypatch.setattr(BackendApiConnector, "__init__", __init__)
 
-    response = IdentifiersResponse(identifiers=[extracted_person.identifier])
-    post_extracted_items = Mock(return_value=response)
-    monkeypatch.setattr(
-        BackendApiConnector, "post_extracted_items", post_extracted_items
-    )
+    response = ItemsContainer[ExtractedPerson](items=[extracted_person])
+    ingest = Mock(return_value=response)
+    monkeypatch.setattr(BackendApiConnector, "ingest", ingest)
 
     sink = BackendApiSink.get()
-    model_ids = list(sink.load([extracted_person]))
-    assert model_ids == response.identifiers
-    post_extracted_items.assert_called_once_with([extracted_person])
+    models_or_rule_sets = list(sink.load([extracted_person]))
+    assert models_or_rule_sets == [extracted_person]
+    ingest.assert_called_once_with([extracted_person])

--- a/tests/sinks/test_ndjson.py
+++ b/tests/sinks/test_ndjson.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 from pydantic import UUID4
 
-from mex.common.models import ExtractedData
+from mex.common.models import BaseModel
 from mex.common.settings import BaseSettings
 from mex.common.sinks.ndjson import NdjsonSink
 from mex.common.types import Identifier, TemporalEntity
@@ -13,7 +13,7 @@ class DummyEnum(Enum):
     NAME = "value"
 
 
-class ExtractedThing(ExtractedData):
+class Thing(BaseModel):
     identifier: Identifier
     str_attr: str
     enum_attr: DummyEnum | None = None
@@ -21,31 +21,21 @@ class ExtractedThing(ExtractedData):
     ts_attr: TemporalEntity | None = None
 
 
-class RuleThing:
-    pass
-
-
 def test_sink_load() -> None:
     settings = BaseSettings.get()
 
     test_models = [
-        ExtractedThing.model_construct(identifier="1", str_attr="foo"),
-        ExtractedThing.model_construct(
-            identifier="2", str_attr="bar", enum_attr=DummyEnum.NAME
-        ),
-        ExtractedThing.model_construct(
-            identifier="3", str_attr="baz", uuid_attr=UUID(int=42, version=4)
-        ),
-        ExtractedThing.model_construct(
-            identifier="4", str_attr="dat", ts_attr=TemporalEntity(2000, 1, 1)
-        ),
+        Thing(identifier="1", str_attr="foo"),
+        Thing(identifier="2", str_attr="bar", enum_attr=DummyEnum.NAME),
+        Thing(identifier="3", str_attr="baz", uuid_attr=UUID(int=42, version=4)),
+        Thing(identifier="4", str_attr="dat", ts_attr=TemporalEntity(2000, 1, 1)),
     ]
 
     sink = NdjsonSink.get()
     ids = list(sink.load(test_models))
     assert len(ids)
 
-    with open(settings.work_dir / "ExtractedThing.ndjson") as handle:
+    with open(settings.work_dir / "Thing.ndjson") as handle:
         output = handle.read()
 
     expected = """\

--- a/tests/sinks/test_ndjson.py
+++ b/tests/sinks/test_ndjson.py
@@ -25,10 +25,22 @@ def test_sink_load() -> None:
     settings = BaseSettings.get()
 
     test_models = [
-        Thing(identifier="1", str_attr="foo"),
-        Thing(identifier="2", str_attr="bar", enum_attr=DummyEnum.NAME),
-        Thing(identifier="3", str_attr="baz", uuid_attr=UUID(int=42, version=4)),
-        Thing(identifier="4", str_attr="dat", ts_attr=TemporalEntity(2000, 1, 1)),
+        Thing(identifier=Identifier.generate(seed=1), str_attr="foo"),
+        Thing(
+            identifier=Identifier.generate(seed=2),
+            str_attr="bar",
+            enum_attr=DummyEnum.NAME,
+        ),
+        Thing(
+            identifier=Identifier.generate(seed=3),
+            str_attr="baz",
+            uuid_attr=UUID(int=42, version=4),
+        ),
+        Thing(
+            identifier=Identifier.generate(seed=4),
+            str_attr="dat",
+            ts_attr=TemporalEntity(2000, 1, 1),
+        ),
     ]
 
     sink = NdjsonSink.get()

--- a/tests/sinks/test_ndjson.py
+++ b/tests/sinks/test_ndjson.py
@@ -21,6 +21,10 @@ class ExtractedThing(ExtractedData):
     ts_attr: TemporalEntity | None = None
 
 
+class RuleThing:
+    pass
+
+
 def test_sink_load() -> None:
     settings = BaseSettings.get()
 


### PR DESCRIPTION
### Changes

- BREAKING: move ItemsContainer and PaginatedItemsContainer to mex.common.models
- BREAKING: replace post_extracted_items with ingest and allow AnyRuleSetResponses
- allow AnyRuleSetResponses as arguments to sinks
- BREAKING: sinks now yield the models they loaded, instead of just their identifiers
