### PR TITLE
feature/mx-1760 s3 sinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- add entry for `s3` to sink settings enum
+
 ### Changes
+
+- add `AnyMergedModel` to the allowed types for `Sink.load` methods
+- but let BackendApiSink throw an error, when merged items are loaded
+- make local typevars private and give them speaking names
 
 ### Deprecated
 

--- a/mex/common/models/base/container.py
+++ b/mex/common/models/base/container.py
@@ -2,17 +2,17 @@ from typing import Generic, TypeVar
 
 from pydantic import BaseModel
 
-T = TypeVar("T")
+_ContainerItemT = TypeVar("_ContainerItemT")
 
 
-class ItemsContainer(BaseModel, Generic[T]):
+class ItemsContainer(BaseModel, Generic[_ContainerItemT]):
     """Generic container that contains items."""
 
-    items: list[T]
+    items: list[_ContainerItemT]
 
 
-class PaginatedItemsContainer(BaseModel, Generic[T]):
+class PaginatedItemsContainer(BaseModel, Generic[_ContainerItemT]):
     """Generic container that contains items and has a total item count."""
 
-    items: list[T]
+    items: list[_ContainerItemT]
     total: int

--- a/mex/common/models/base/mapping.py
+++ b/mex/common/models/base/mapping.py
@@ -2,18 +2,19 @@ from typing import Annotated, Generic, TypeVar
 
 from pydantic import BaseModel, Field
 
-T = TypeVar("T")
+_ValueT = TypeVar("_ValueT")
+_MappingRuleT = TypeVar("_MappingRuleT")
 
 
-class MappingRule(BaseModel, Generic[T], extra="forbid"):
+class MappingRule(BaseModel, Generic[_ValueT], extra="forbid"):
     """Generic mapping rule model."""
 
     forValues: Annotated[list[str] | None, Field(title="forValues")] = None
-    setValues: Annotated[T | None, Field(title="setValues")] = None
+    setValues: Annotated[_ValueT | None, Field(title="setValues")] = None
     rule: Annotated[str | None, Field(title="rule")] = None
 
 
-class MappingField(BaseModel, Generic[T], extra="forbid"):
+class MappingField(BaseModel, Generic[_MappingRuleT], extra="forbid"):
     """Generic mapping field model."""
 
     fieldInPrimarySource: Annotated[str | None, Field(title="fieldInPrimarySource")] = (
@@ -26,7 +27,7 @@ class MappingField(BaseModel, Generic[T], extra="forbid"):
         list[str] | None, Field(title="examplesInPrimarySource")
     ] = None
     mappingRules: Annotated[
-        list[MappingRule[T]], Field(min_length=1, title="mappingRules")
+        list[MappingRule[_MappingRuleT]], Field(min_length=1, title="mappingRules")
     ]
     comment: Annotated[str | None, Field(title="comment")] = None
 

--- a/mex/common/sinks/backend_api.py
+++ b/mex/common/sinks/backend_api.py
@@ -2,7 +2,7 @@ from collections.abc import Generator, Iterable
 
 from mex.common.backend_api.connector import BackendApiConnector
 from mex.common.logging import logger
-from mex.common.models import AnyExtractedModel, AnyRuleSetResponse
+from mex.common.models import AnyExtractedModel, AnyMergedModel, AnyRuleSetResponse
 from mex.common.sinks.base import BaseSink
 from mex.common.utils import grouper
 
@@ -13,21 +13,29 @@ class BackendApiSink(BaseSink):
     CHUNK_SIZE = 50
 
     def load(
-        self,
-        models_or_rule_sets: Iterable[AnyExtractedModel | AnyRuleSetResponse],
-    ) -> Generator[AnyExtractedModel | AnyRuleSetResponse, None, None]:
+        self, items: Iterable[AnyExtractedModel | AnyMergedModel | AnyRuleSetResponse]
+    ) -> Generator[AnyExtractedModel | AnyMergedModel | AnyRuleSetResponse, None, None]:
         """Load extracted models or rule-sets to the Backend API using bulk insertion.
 
         Args:
-            models_or_rule_sets: Iterable of extracted models or rule-sets
+            items: Iterable of extracted models or rule-sets
+
+        Raises:
+            NotImplementedError: When you try to load merged items into the backend
 
         Returns:
             Generator for posted models
         """
         total_count = 0
         connector = BackendApiConnector.get()
-        for chunk in grouper(self.CHUNK_SIZE, models_or_rule_sets):
-            model_list = [model for model in chunk if model is not None]
+        for chunk in grouper(self.CHUNK_SIZE, items):
+            model_list = []
+            for model in chunk:
+                if isinstance(model, AnyExtractedModel | AnyRuleSetResponse):
+                    model_list.append(model)
+                elif model is not None:
+                    msg = f"backend cannot ingest {type(model)}"
+                    raise NotImplementedError(msg)
             connector.ingest(model_list)
             total_count += len(model_list)
             yield from model_list

--- a/mex/common/sinks/backend_api.py
+++ b/mex/common/sinks/backend_api.py
@@ -18,7 +18,7 @@ class BackendApiSink(BaseSink):
         """Load extracted models or rule-sets to the Backend API using bulk insertion.
 
         Args:
-            items: Iterable of extracted models or rule-sets
+            items: Iterable of extracted models or merged models or rule-sets
 
         Raises:
             NotImplementedError: When you try to load merged items into the backend

--- a/mex/common/sinks/base.py
+++ b/mex/common/sinks/base.py
@@ -2,7 +2,7 @@ from abc import abstractmethod
 from collections.abc import Generator, Iterable
 
 from mex.common.connector import BaseConnector
-from mex.common.models import AnyExtractedModel, AnyRuleSetResponse
+from mex.common.models import AnyExtractedModel, AnyMergedModel, AnyRuleSetResponse
 
 
 class BaseSink(BaseConnector):
@@ -17,9 +17,9 @@ class BaseSink(BaseConnector):
     @abstractmethod
     def load(
         self,
-        models_or_rule_sets: Iterable[AnyExtractedModel | AnyRuleSetResponse],
+        items: Iterable[AnyExtractedModel | AnyMergedModel | AnyRuleSetResponse],
     ) -> Generator[
-        AnyExtractedModel | AnyRuleSetResponse, None, None
+        AnyExtractedModel | AnyMergedModel | AnyRuleSetResponse, None, None
     ]:  # pragma: no cover
-        """Load extracted models or rule-sets to a destination and yield them."""
+        """Load the given items to a destination and yield them."""
         ...

--- a/mex/common/sinks/registry.py
+++ b/mex/common/sinks/registry.py
@@ -2,7 +2,7 @@ from collections.abc import Generator, Iterable
 from itertools import tee
 from typing import Final
 
-from mex.common.models import AnyExtractedModel, AnyRuleSetResponse
+from mex.common.models import AnyExtractedModel, AnyMergedModel, AnyRuleSetResponse
 from mex.common.settings import BaseSettings
 from mex.common.sinks.backend_api import BackendApiSink
 from mex.common.sinks.base import BaseSink
@@ -37,11 +37,11 @@ class _MultiSink(BaseSink):
 
     def load(
         self,
-        models_or_rule_sets: Iterable[AnyExtractedModel | AnyRuleSetResponse],
-    ) -> Generator[AnyExtractedModel | AnyRuleSetResponse, None, None]:
-        """Load models or rule-sets to multiple sinks simultaneously."""
+        items: Iterable[AnyExtractedModel | AnyMergedModel | AnyRuleSetResponse],
+    ) -> Generator[AnyExtractedModel | AnyMergedModel | AnyRuleSetResponse, None, None]:
+        """Load the given items to multiple sinks simultaneously."""
         for sink, model_gen in zip(
-            self._sinks, tee(models_or_rule_sets, len(self._sinks)), strict=True
+            self._sinks, tee(items, len(self._sinks)), strict=True
         ):
             yield from sink.load(model_gen)
 

--- a/mex/common/types/sink.py
+++ b/mex/common/types/sink.py
@@ -7,3 +7,4 @@ class Sink(Enum):
     BACKEND = "backend"
     GRAPH = "graph"
     NDJSON = "ndjson"
+    S3 = "s3"

--- a/tests/sinks/test_backend_api.py
+++ b/tests/sinks/test_backend_api.py
@@ -1,9 +1,10 @@
 from unittest.mock import MagicMock, Mock
 
+import pytest
 from pytest import MonkeyPatch
 
 from mex.common.backend_api.connector import BackendApiConnector
-from mex.common.models import ExtractedPerson, ItemsContainer
+from mex.common.models import ExtractedPerson, ItemsContainer, MergedPerson
 from mex.common.sinks.backend_api import BackendApiSink
 
 
@@ -23,3 +24,16 @@ def test_sink_load_mocked(
     models_or_rule_sets = list(sink.load([extracted_person]))
     assert models_or_rule_sets == [extracted_person]
     ingest.assert_called_once_with([extracted_person])
+
+
+def test_sink_load_merged_error(
+    merged_person: MergedPerson, monkeypatch: MonkeyPatch
+) -> None:
+    def __init__(self: BackendApiConnector) -> None:
+        self.session = MagicMock()
+
+    monkeypatch.setattr(BackendApiConnector, "__init__", __init__)
+
+    sink = BackendApiSink.get()
+    with pytest.raises(NotImplementedError, match="backend cannot"):
+        list(sink.load([merged_person]))


### PR DESCRIPTION
### PR Context

- prep for https://github.com/robert-koch-institut/mex-extractors/pull/331

### Added

- add entry for `s3` to sink settings enum

### Changes

- add `AnyMergedModel` to the allowed types for `Sink.load` methods
- but let BackendApiSink throw an error, when merged items are loaded
- make local typevars private and give them speaking names
