### PR TITLE
Bump cookiecutter template to 71224c

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "checkout": null,
-  "commit": "5446dae8486bd2412e75f97790c6bd800fa26a34",
+  "commit": "71224cdf6b9828906fd1591f7572bdb12f8f9408",
   "context": {
     "cookiecutter": {
       "project_name": "common",
       "short_summary": "Common library for MEx python projects.",
       "long_summary": "The `mex-common` library is a software development toolkit that is used by multiple components within the MEx project. It contains utilities for building pipelines like a common commandline interface, logging and configuration setup. It also provides common auxiliary connectors that can be used to fetch data from external services and a re-usable implementation of the MEx metadata schema as pydantic models.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "5446dae8486bd2412e75f97790c6bd800fa26a34"
+      "_commit": "71224cdf6b9828906fd1591f7572bdb12f8f9408"
     }
   },
   "directory": null,

--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,11 @@ dmypy.json
 # SQLite databases
 *.db
 
+# Reflex
+.states
+assets/external/
+.web
+
 # Default exports
 *.ndjson
 data/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
   python: python3.11
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.1
+    rev: v0.9.6
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -25,7 +25,7 @@ repos:
       - id: fix-byte-order-marker
         name: byte-order
   - repo: https://github.com/pdm-project/pdm
-    rev: 2.22.2
+    rev: 2.22.3
     hooks:
       - id: pdm-lock-check
         name: pdm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,9 @@ select = ["ALL"]
 "mex/common/models/resource.py" = [
     "A005",     # Allow module for resource models to shadow standard-library
 ]
+"mex/common/types/__init__.py" = [
+    "A005",     # Allow custom types module to shadow standard-library
+]
 "mex/common/types/email.py" = [
     "A005",     # Allow custom email types module to shadow standard-library
 ]
@@ -142,6 +145,7 @@ select = ["ALL"]
     "INP001",   # Scripts folder does not need to be a package
 ]
 "tests/**" = [
+    "A005",     # Allow modules shadowing standard-library modules
     "ARG005",   # Allow unused lambda arguments for mocking
     "D101",     # Allow missing docstring in public class
     "D102",     # Allow missing docstring in public method


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/71224c
