### PR TITLE
Bump cookiecutter template to 8bdad0

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "checkout": null,
-  "commit": "71224cdf6b9828906fd1591f7572bdb12f8f9408",
+  "commit": "8bdad06a5eca52607f046b75cb0cdd9d7ab4912e",
   "context": {
     "cookiecutter": {
       "project_name": "common",
       "short_summary": "Common library for MEx python projects.",
       "long_summary": "The `mex-common` library is a software development toolkit that is used by multiple components within the MEx project. It contains utilities for building pipelines like a common commandline interface, logging and configuration setup. It also provides common auxiliary connectors that can be used to fetch data from external services and a re-usable implementation of the MEx metadata schema as pydantic models.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "71224cdf6b9828906fd1591f7572bdb12f8f9408"
+      "_commit": "8bdad06a5eca52607f046b75cb0cdd9d7ab4912e"
     }
   },
   "directory": null,


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/8bdad0
