### PR TITLE
reduce chunk size for backend api sink to avoid timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- reduce chunk size for backend api sink to avoid timeouts
+
 ### Deprecated
 
 ### Removed

--- a/mex/common/sinks/backend_api.py
+++ b/mex/common/sinks/backend_api.py
@@ -10,7 +10,7 @@ from mex.common.utils import grouper
 class BackendApiSink(BaseSink):
     """Sink to load models to the Backend API."""
 
-    CHUNK_SIZE = 50
+    CHUNK_SIZE = 25
 
     def load(
         self, items: Iterable[AnyExtractedModel | AnyMergedModel | AnyRuleSetResponse]


### PR DESCRIPTION


### Changes
<!-- Changes in existing functionality -->
- reduce chunk size for backend api sink to avoid timeouts
