### PR TITLE
Feature/mx 1737 refactor http connector for endnote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- BREAKING: request method of HTTPConnector return Response unless specified otherwise
+
 ### Deprecated
 
 ### Removed

--- a/mex/common/backend_api/connector.py
+++ b/mex/common/backend_api/connector.py
@@ -60,6 +60,9 @@ class BackendApiConnector(HTTPConnector):
             payload=ItemsContainer[AnyExtractedModel | AnyRuleSetResponse](
                 items=models_or_rule_sets
             ),
+            params={
+                "format": "json",
+            },
             timeout=self.INGEST_TIMEOUT,
         )
         return (
@@ -95,6 +98,7 @@ class BackendApiConnector(HTTPConnector):
             method="GET",
             endpoint="extracted-item",
             params={
+                "format": "json",
                 "q": query_string,
                 "stableTargetId": stable_target_id,
                 "entityType": entity_type,
@@ -131,6 +135,7 @@ class BackendApiConnector(HTTPConnector):
             method="GET",
             endpoint="merged-item",
             params={
+                "format": "json",
                 "q": query_string,
                 "entityType": entity_type,
                 "hadPrimarySource": had_primary_source,
@@ -160,6 +165,7 @@ class BackendApiConnector(HTTPConnector):
             method="GET",
             endpoint="merged-item",
             params={
+                "format": "json",
                 "identifier": identifier,
                 "limit": "1",
             },
@@ -194,6 +200,9 @@ class BackendApiConnector(HTTPConnector):
             method="POST",
             endpoint=f"preview-item/{stable_target_id}",
             payload=rule_set,
+            params={
+                "format": "json",
+            },
         )
         return MergedModelTypeAdapter.validate_python(response)
 
@@ -224,6 +233,7 @@ class BackendApiConnector(HTTPConnector):
             method="GET",
             endpoint="preview-item",
             params={
+                "format": "json",
                 "q": query_string,
                 "entityType": entity_type,
                 "hadPrimarySource": had_primary_source,
@@ -251,5 +261,8 @@ class BackendApiConnector(HTTPConnector):
         response = self.request(
             method="GET",
             endpoint=f"rule-set/{stable_target_id}",
+            params={
+                "format": "json",
+            },
         )
         return RuleSetResponseTypeAdapter.validate_python(response)

--- a/mex/common/connector/http.py
+++ b/mex/common/connector/http.py
@@ -51,7 +51,7 @@ class HTTPConnector(BaseConnector):
         payload: Any = None,
         params: Mapping[str, list[str] | str | None] | None = None,
         **kwargs: Any,
-    ) -> dict[str, Any]:
+    ) -> dict[str, Any] | Response:
         """Prepare and send a request with error handling and payload de/serialization.
 
         Args:
@@ -96,7 +96,9 @@ class HTTPConnector(BaseConnector):
 
         if response.status_code == codes.no_content:
             return {}
-        return cast("dict[str, Any]", response.json())
+        if (params) and params.get("format") == "json":
+            return cast("dict[str, Any]", response.json())
+        return response
 
     @backoff.on_predicate(
         backoff.fibo,

--- a/mex/common/identity/backend_api.py
+++ b/mex/common/identity/backend_api.py
@@ -20,7 +20,8 @@ class BackendApiIdentityProvider(BaseProvider, BackendApiConnector):
         response = self.request(
             "POST",
             "identity",
-            {
+            params={
+                "format": "json",
                 "hadPrimarySource": had_primary_source,
                 "identifierInPrimarySource": identifier_in_primary_source,
             },
@@ -43,6 +44,7 @@ class BackendApiIdentityProvider(BaseProvider, BackendApiConnector):
             "GET",
             "identity",
             params={
+                "format": "json",
                 "hadPrimarySource": had_primary_source,
                 "identifierInPrimarySource": identifier_in_primary_source,
                 "stableTargetId": stable_target_id,

--- a/mex/common/wikidata/connector.py
+++ b/mex/common/wikidata/connector.py
@@ -51,4 +51,4 @@ class WikidataAPIConnector(HTTPConnector):
                 "formatversion": "2",
             },
         )
-        return cast("dict[str, str]", results["entities"][item_id])
+        return cast("dict[str, str]", results["entities"][item_id])  # type: ignore[index]

--- a/tests/backend_api/test_connector.py
+++ b/tests/backend_api/test_connector.py
@@ -38,7 +38,7 @@ def test_ingest_mocked(
     assert mocked_backend.call_args == call(
         "POST",
         "http://localhost:8080/v0/ingest",
-        None,
+        {"format": "json"},
         headers={
             "Accept": "application/json",
             "User-Agent": "rki/mex",
@@ -74,6 +74,7 @@ def test_fetch_extracted_items_mocked(
         "GET",
         "http://localhost:8080/v0/extracted-item",
         {
+            "format": "json",
             "q": "Tintzmann",
             "stableTargetId": "NGwfzG8ROsrvIiQIVDVy",
             "entityType": ["ExtractedPerson", "ExtractedContactPoint"],
@@ -110,6 +111,7 @@ def test_fetch_merged_items_mocked(
         "GET",
         "http://localhost:8080/v0/merged-item",
         {
+            "format": "json",
             "q": "Tintzmann",
             "entityType": ["MergedPerson", "MergedContactPoint"],
             "hadPrimarySource": None,
@@ -139,6 +141,7 @@ def test_get_merged_item_mocked(
         "GET",
         "http://localhost:8080/v0/merged-item",
         {
+            "format": "json",
             "identifier": "NGwfzG8ROsrvIiQIVDVy",
             "limit": "1",
         },
@@ -162,6 +165,7 @@ def test_get_merged_item_error_mocked(mocked_backend: MagicMock) -> None:
         "GET",
         "http://localhost:8080/v0/merged-item",
         {
+            "format": "json",
             "identifier": "NGwfzG8ROsrvIiQIVDVy",
             "limit": "1",
         },
@@ -189,7 +193,7 @@ def test_preview_merged_item_mocked(
     assert mocked_backend.call_args == call(
         "POST",
         "http://localhost:8080/v0/preview-item/NGwfzG8ROsrvIiQIVDVy",
-        None,
+        {"format": "json"},
         headers={
             "Accept": "application/json",
             "User-Agent": "rki/mex",
@@ -222,6 +226,7 @@ def test_fetch_preview_items_mocked(
         "GET",
         "http://localhost:8080/v0/preview-item",
         {
+            "format": "json",
             "q": "foobar",
             "entityType": None,
             "hadPrimarySource": None,
@@ -249,7 +254,7 @@ def test_get_rule_set_mocked(
     assert mocked_backend.call_args == call(
         "GET",
         "http://localhost:8080/v0/rule-set/NGwfzG8ROsrvIiQIVDVy",
-        None,
+        {"format": "json"},
         headers={
             "Accept": "application/json",
             "User-Agent": "rki/mex",

--- a/tests/connector/test_base.py
+++ b/tests/connector/test_base.py
@@ -21,6 +21,7 @@ def test_connector_get() -> None:
 
 
 def test_connector_store_reset() -> None:
+    CONNECTOR_STORE.reset()
     connector = DummyConnector.get()
     assert len(list(CONNECTOR_STORE)) == 1
 

--- a/tests/connector/test_http.py
+++ b/tests/connector/test_http.py
@@ -229,7 +229,9 @@ def test_request_failure(  # noqa: PLR0913
     connector = DummyHTTPConnector.get()
 
     try:
-        response_or_error: Any = connector.request("POST", "things", payload=[])
+        response_or_error: Any = connector.request(
+            "POST", "things", payload=[], params={"format": "json"}
+        )
     except RequestException as error:
         response_or_error = repr(error)
 

--- a/tests/connector/test_http.py
+++ b/tests/connector/test_http.py
@@ -120,13 +120,22 @@ def test_request_success(
 
     connector = DummyHTTPConnector.get()
 
-    actual_response = connector.request("POST", "things", payload=sent_payload)
+    actual_response = connector.request(
+        "POST",
+        "things",
+        payload=sent_payload,
+        params={
+            "format": "json",
+        },
+    )
 
     assert actual_response == expected_response
     assert mocked_session.request.call_args_list[-1] == call(
         "POST",
         "https://www.example.com/things",
-        None,
+        {
+            "format": "json",
+        },
         timeout=DummyHTTPConnector.TIMEOUT,
         **expected_kwargs,
     )

--- a/tests/identity/test_backend_api.py
+++ b/tests/identity/test_backend_api.py
@@ -128,6 +128,7 @@ def test_fetch_mocked_empty(
         "GET",
         "http://localhost:8080/v0/identity",
         {
+            "format": "json",
             "hadPrimarySource": None,
             "identifierInPrimarySource": None,
             "stableTargetId": None,


### PR DESCRIPTION
### PR Context

- Endnote needs raw Response of HTTPConnector to extract XML files. JSON will now only be returned when specified as format. Params handling for that is implemented analogous to the wikidata connector.

### Changes

- BREAKING: request method of HTTPConnector return Response unless specified otherwise
