### PR TITLE
MX-1726 Highlight required fields in the mex-editor edit view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
+- added utility method for a cached list of fields that can be set to an empty list 'get_field_names_allowing_empty_list'
+- will be used to highlight required field in mex-editor in the edit view
 ### Changes
 
 ### Deprecated

--- a/mex/common/fields.py
+++ b/mex/common/fields.py
@@ -169,3 +169,14 @@ FINAL_FIELDS_BY_CLASS_NAME = {
     )
     for name, cls in ALL_MODEL_CLASSES_BY_NAME.items()
 }
+
+REQUIRED_FIELDS_BY_CLASS_NAME = {
+    name: sorted(
+        {
+            field_name
+            for field_name, field_info in cls.model_fields.items()
+            if field_info.is_required()
+        }
+    )
+    for name, cls in ALL_MODEL_CLASSES_BY_NAME.items()
+}

--- a/mex/common/utils.py
+++ b/mex/common/utils.py
@@ -172,6 +172,20 @@ def get_field_names_allowing_none(model: type[BaseModel]) -> list[str]:
     return field_names
 
 
+@lru_cache(maxsize=4048)
+def get_field_names_allowing_empty_list(model: type[BaseModel]) -> list[str]:
+    """Build a cached list of fields can be set to an empty list."""
+    field_names: list[str] = []
+    for field_name, field_info in get_all_fields(model).items():
+        validator: TypeAdapter[Any] = TypeAdapter(field_info.annotation)
+        try:
+            validator.validate_python([])
+        except ValidationError:
+            continue
+        field_names.append(field_name)
+    return field_names
+
+
 def group_fields_by_class_name(
     model_classes_by_name: Mapping[str, type[BaseModel]],
     predicate: Callable[[GenericFieldInfo], bool],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,6 +21,7 @@ from mex.common.utils import (
     contains_only_types,
     get_alias_lookup,
     get_all_fields,
+    get_field_names_allowing_empty_list,
     get_field_names_allowing_none,
     get_inner_types,
     get_list_field_names,
@@ -194,6 +195,13 @@ def test_get_field_names_allowing_none() -> None:
     assert get_field_names_allowing_none(ComplexDummyModel) == [
         "optional_str",
         "optional_list",
+    ]
+
+
+def test_get_field_names_allowing_empty_list() -> None:
+    assert get_field_names_allowing_empty_list(ComplexDummyModel) == [
+        "optional_list",
+        "required_list",
     ]
 
 


### PR DESCRIPTION
### PR Context
- In the edit view of the mex-editor, we want to highlight required fields.
- required fields can be either single value non-nullable fields or array fields with a minimum length of one


### Added
- added utility method for a cached list of fields that can be set to an empty list 'get_field_names_allowing_empty_list'
- will be used to highlight required field in mex-editor in the edit view
