### PR TITLE
Bump cookiecutter template to 7de6ba

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "checkout": null,
-  "commit": "ed5deb106b3d34aa758dcd4f4d3628a1ffb2b159",
+  "commit": "7de6bafd6cadfebd1fdaff228960adc884bb48b5",
   "context": {
     "cookiecutter": {
       "project_name": "common",
       "short_summary": "Common library for MEx python projects.",
       "long_summary": "The `mex-common` library is a software development toolkit that is used by multiple components within the MEx project. It contains utilities for building pipelines like a common commandline interface, logging and configuration setup. It also provides common auxiliary connectors that can be used to fetch data from external services and a re-usable implementation of the MEx metadata schema as pydantic models.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "ed5deb106b3d34aa758dcd4f4d3628a1ffb2b159"
+      "_commit": "7de6bafd6cadfebd1fdaff228960adc884bb48b5"
     }
   },
   "directory": null,


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/7de6ba
