### PR TITLE
feature/mx-1954 fix wiki labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- use default wiki label should there be neither a german nor english label
+
 ### Deprecated
 
 ### Removed

--- a/mex/common/wikidata/models.py
+++ b/mex/common/wikidata/models.py
@@ -65,7 +65,7 @@ class Claims(BaseModel):
 class Label(BaseModel):
     """Model class for single Label."""
 
-    language: str
+    language: str | None = None
     value: str
 
 
@@ -74,6 +74,7 @@ class Labels(BaseModel):
 
     de: Label | None = None
     en: Label | None = None
+    multiple: Annotated[Label | None, Field(alias="mul")] = None
 
 
 class Alias(BaseModel):

--- a/mex/common/wikidata/transform.py
+++ b/mex/common/wikidata/transform.py
@@ -44,7 +44,7 @@ def transform_wikidata_organization_to_extracted_organization(
     Returns:
         ExtractedOrganization or None
     """
-    labels = _get_clean_labels(wikidata_organization.labels)
+    labels = get_official_name_label(wikidata_organization.labels)
     if not labels:
         return None
     return ExtractedOrganization(
@@ -148,19 +148,19 @@ def _get_clean_short_names(short_names: Sequence[Claim]) -> list[Text]:
     return clean_short_names
 
 
-def _get_clean_labels(labels: Labels) -> list[Text]:
-    """Check if DE label is available and return a list of EN and DE labels.
+def get_official_name_label(labels: Labels) -> Text | None:
+    """Get if DE label is available and return a list of EN and DE labels.
 
     Args:
-        labels: labels object
+        labels: Wikidata labels object
 
     Returns:
-        list of clean labels in EN and DE
+        Text object of the label that was picked, or None
     """
-    clean_labels = []
-    if labels.en:
-        clean_labels.append(Text(value=labels.en.value, language=TextLanguage.EN))
     if labels.de:
-        clean_labels.append(Text(value=labels.de.value, language=TextLanguage.DE))
-
-    return clean_labels
+        return Text(value=labels.de.value, language=TextLanguage.DE)
+    if labels.en:
+        return Text(value=labels.en.value, language=TextLanguage.EN)
+    if labels.multiple:
+        return Text(value=labels.multiple.value, language=None)
+    return None

--- a/tests/wikidata/test_extract.py
+++ b/tests/wikidata/test_extract.py
@@ -114,6 +114,7 @@ def test_get_wikidata_organization_mocked(monkeypatch: MonkeyPatch) -> None:
         "labels": {
             "de": {"language": "de", "value": "TEST"},
             "en": {"language": "en", "value": "TEST"},
+            "multiple": None,
         },
         "claims": {
             "website": [


### PR DESCRIPTION
### PR Context

- mapping was already updated accordingly
- editor bug will be fixed once this change has been integrated into the backend

### Changes

- use default wiki label should there be neither a german nor english label
