### PR TITLE
feature/mx-1856 prep consent mailer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
-- use default wiki label should there be neither a german nor english label
-
 ### Deprecated
 
 ### Removed
@@ -20,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+
+## [0.64.0] - 2025-07-24
+
+### Changes
+
+- use default wiki label should there be neither a german nor english label
 
 ## [0.63.0] - 2025-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add identifier filter to merged and preview fetch endpoints in
-    Backend API
-- Add fetch all merged items method to Backend API connector
+- add identifier filter to merged and preview fetch endpoints in BackendApiConnector
+- add `fetch_all_merged_items` and `get_extracted_item` methods to BackendApiConnector
 
 ### Changes
 
-- BREAKING: replace hadPrimarySource with reference fields in Backend API
-    fetch endpoints
-- BREAKING: Backend API fetch endpoint now expects keyword arguments
+- BREAKING: replace hadPrimarySource with reference field filter in BackendApiConnector
+- BREAKING: BackendApiConnector fetch endpoint methods now expect keyword arguments
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add identifier filter to merged and preview fetch endpoints in
+    Backend API
+- Add fetch all merged items method to Backend API connector
+
 ### Changes
+
+- BREAKING: replace hadPrimarySource with reference fields in Backend API
+    fetch endpoints
+- BREAKING: Backend API fetch endpoint now expects keyword arguments
 
 ### Deprecated
 

--- a/mex/common/backend_api/connector.py
+++ b/mex/common/backend_api/connector.py
@@ -1,7 +1,6 @@
+from collections.abc import Generator
 from typing import Any, TypeVar
 from urllib.parse import urljoin
-
-from requests.exceptions import HTTPError
 
 from mex.common.connector import HTTPConnector
 from mex.common.identity.models import Identity
@@ -14,6 +13,7 @@ from mex.common.models import (
     ExtractedOrganization,
     ExtractedPerson,
     ItemsContainer,
+    MergedModelTypeAdapter,
     PaginatedItemsContainer,
     PreviewModelTypeAdapter,
     RuleSetResponseTypeAdapter,
@@ -45,13 +45,16 @@ class BackendApiConnector(HTTPConnector):
         settings = BaseSettings.get()
         self.url = urljoin(str(settings.backend_api_url), self.API_VERSION)
 
-    def fetch_extracted_items(
+    def fetch_extracted_items(  # noqa: PLR0913
         self,
-        query_string: str | None,
-        stable_target_id: str | None,
-        entity_type: list[str] | None,
-        skip: int,
-        limit: int,
+        *,
+        query_string: str | None = None,
+        stable_target_id: str | None = None,
+        entity_type: list[str] | None = None,
+        referenced_identifier: list[str] | None = None,
+        reference_field: str | None = None,
+        skip: int = 0,
+        limit: int = 100,
     ) -> PaginatedItemsContainer[AnyExtractedModel]:
         """Fetch extracted items that match the given set of filters.
 
@@ -59,6 +62,8 @@ class BackendApiConnector(HTTPConnector):
             query_string: Full-text search query
             stable_target_id: The item's stableTargetId
             entity_type: The item's entityType
+            referenced_identifier: Optional merged item identifiers filter
+            reference_field: Optional field name to filter for
             skip: How many items to skip for pagination
             limit: How many items to return in one page
 
@@ -75,26 +80,33 @@ class BackendApiConnector(HTTPConnector):
                 "q": query_string,
                 "stableTargetId": stable_target_id,
                 "entityType": entity_type,
+                "referencedIdentifier": referenced_identifier,
+                "referenceField": reference_field,
                 "skip": str(skip),
                 "limit": str(limit),
             },
         )
         return PaginatedItemsContainer[AnyExtractedModel].model_validate(response)
 
-    def fetch_merged_items(
+    def fetch_merged_items(  # noqa: PLR0913
         self,
-        query_string: str | None,
-        entity_type: list[str] | None,
-        had_primary_source: list[str] | None,
-        skip: int,
-        limit: int,
+        *,
+        query_string: str | None = None,
+        identifier: str | None = None,
+        entity_type: list[str] | None = None,
+        referenced_identifier: list[str] | None = None,
+        reference_field: str | None = None,
+        skip: int = 0,
+        limit: int = 100,
     ) -> PaginatedItemsContainer[AnyMergedModel]:
         """Fetch merged items that match the given set of filters.
 
         Args:
             query_string: Full-text search query
+            identifier: Optional merged item identifier filter
             entity_type: The items' entityType
-            had_primary_source: The items' hadPrimarySource
+            referenced_identifier: Optional merged item identifiers filter
+            reference_field: Optional field name to filter for
             skip: How many items to skip for pagination
             limit: How many items to return in one page
 
@@ -109,13 +121,62 @@ class BackendApiConnector(HTTPConnector):
             endpoint="merged-item",
             params={
                 "q": query_string,
+                "identifier": identifier,
                 "entityType": entity_type,
-                "hadPrimarySource": had_primary_source,
+                "referencedIdentifier": referenced_identifier,
+                "referenceField": reference_field,
                 "skip": str(skip),
                 "limit": str(limit),
             },
         )
         return PaginatedItemsContainer[AnyMergedModel].model_validate(response)
+
+    def fetch_all_merged_items(
+        self,
+        *,
+        query_string: str | None = None,
+        identifier: str | None = None,
+        entity_type: list[str] | None = None,
+        referenced_identifier: list[str] | None = None,
+        reference_field: str | None = None,
+    ) -> Generator[AnyMergedModel, None, None]:
+        """Fetch all merged items that match the given set of filters.
+
+        Args:
+            query_string: Full-text search query
+            identifier: Optional merged item identifier filter
+            entity_type: The items' entityType
+            referenced_identifier: Optional merged item identifiers filter
+            reference_field: Optional field name to filter for
+
+        Raises:
+            HTTPError: If search was not accepted, crashes or times out
+
+        Returns:
+            Generator for all merged items that match the filters
+        """
+        response = self.fetch_merged_items(
+            query_string=query_string,
+            identifier=identifier,
+            entity_type=entity_type,
+            referenced_identifier=referenced_identifier,
+            reference_field=reference_field,
+            skip=0,
+            limit=1,
+        )
+        total_item_number = response.total
+        item_number_limit = 100  # 100 is the maximum possible number per get-request
+        for item_counter in range(0, total_item_number, item_number_limit):
+            response = self.fetch_merged_items(
+                query_string=query_string,
+                identifier=identifier,
+                entity_type=entity_type,
+                referenced_identifier=referenced_identifier,
+                reference_field=reference_field,
+                skip=item_counter,
+                limit=item_number_limit,
+            )
+            yield from response.items
 
     def get_merged_item(
         self,
@@ -132,23 +193,11 @@ class BackendApiConnector(HTTPConnector):
         Returns:
             A single merged item
         """
-        # TODO(ND): stop-gap until backend has proper get merged item endpoint (MX-1669)
         response = self.request(
             method="GET",
-            endpoint="merged-item",
-            params={
-                "identifier": identifier,
-                "limit": "1",
-            },
+            endpoint=f"merged-item/{identifier}",
         )
-        response_model = PaginatedItemsContainer[AnyMergedModel].model_validate(
-            response
-        )
-        try:
-            return response_model.items[0]
-        except IndexError:
-            msg = "merged item was not found"
-            raise HTTPError(msg) from None
+        return MergedModelTypeAdapter.validate_python(response)
 
     def preview_merged_item(
         self,
@@ -174,20 +223,25 @@ class BackendApiConnector(HTTPConnector):
         )
         return PreviewModelTypeAdapter.validate_python(response)
 
-    def fetch_preview_items(
+    def fetch_preview_items(  # noqa: PLR0913
         self,
-        query_string: str | None,
-        entity_type: list[str] | None,
-        had_primary_source: list[str] | None,
-        skip: int,
-        limit: int,
+        *,
+        query_string: str | None = None,
+        identifier: str | None = None,
+        entity_type: list[str] | None = None,
+        referenced_identifier: list[str] | None = None,
+        reference_field: str | None = None,
+        skip: int = 0,
+        limit: int = 100,
     ) -> PaginatedItemsContainer[AnyPreviewModel]:
         """Fetch merged item previews that match the given set of filters.
 
         Args:
             query_string: Full-text search query
+            identifier: Optional merged item identifier filter
             entity_type: The items' entityType
-            had_primary_source: The items' hadPrimarySource
+            referenced_identifier: Optional merged item identifiers filter
+            reference_field: Optional field name to filter for
             skip: How many items to skip for pagination
             limit: How many items to return in one page
 
@@ -202,8 +256,10 @@ class BackendApiConnector(HTTPConnector):
             endpoint="preview-item",
             params={
                 "q": query_string,
+                "identifier": identifier,
                 "entityType": entity_type,
-                "hadPrimarySource": had_primary_source,
+                "referencedIdentifier": referenced_identifier,
+                "referenceField": reference_field,
                 "skip": str(skip),
                 "limit": str(limit),
             },

--- a/mex/common/backend_api/connector.py
+++ b/mex/common/backend_api/connector.py
@@ -63,8 +63,8 @@ class BackendApiConnector(HTTPConnector):
             query_string: Full-text search query
             stable_target_id: The item's stableTargetId
             entity_type: The item's entityType
-            referenced_identifier: Optional merged item identifiers filter
-            reference_field: Optional field name to filter for
+            referenced_identifier: Merged item identifiers filter
+            reference_field: Field name to filter for
             skip: How many items to skip for pagination
             limit: How many items to return in one page
 
@@ -125,10 +125,10 @@ class BackendApiConnector(HTTPConnector):
 
         Args:
             query_string: Full-text search query
-            identifier: Optional merged item identifier filter
+            identifier: Merged item identifier filter
             entity_type: The items' entityType
-            referenced_identifier: Optional merged item identifiers filter
-            reference_field: Optional field name to filter for
+            referenced_identifier: Merged item identifiers filter
+            reference_field: Field name to filter for
             skip: How many items to skip for pagination
             limit: How many items to return in one page
 
@@ -166,10 +166,10 @@ class BackendApiConnector(HTTPConnector):
 
         Args:
             query_string: Full-text search query
-            identifier: Optional merged item identifier filter
+            identifier: Merged item identifier filter
             entity_type: The items' entityType
-            referenced_identifier: Optional merged item identifiers filter
-            reference_field: Optional field name to filter for
+            referenced_identifier: Merged item identifiers filter
+            reference_field: Field name to filter for
 
         Raises:
             HTTPError: If search was not accepted, crashes or times out
@@ -260,10 +260,10 @@ class BackendApiConnector(HTTPConnector):
 
         Args:
             query_string: Full-text search query
-            identifier: Optional merged item identifier filter
+            identifier: Merged item identifier filter
             entity_type: The items' entityType
-            referenced_identifier: Optional merged item identifiers filter
-            reference_field: Optional field name to filter for
+            referenced_identifier: Merged item identifiers filter
+            reference_field: Field name to filter for
             skip: How many items to skip for pagination
             limit: How many items to return in one page
 

--- a/mex/common/backend_api/connector.py
+++ b/mex/common/backend_api/connector.py
@@ -10,6 +10,7 @@ from mex.common.models import (
     AnyPreviewModel,
     AnyRuleSetRequest,
     AnyRuleSetResponse,
+    ExtractedModelTypeAdapter,
     ExtractedOrganization,
     ExtractedPerson,
     ItemsContainer,
@@ -87,6 +88,27 @@ class BackendApiConnector(HTTPConnector):
             },
         )
         return PaginatedItemsContainer[AnyExtractedModel].model_validate(response)
+
+    def get_extracted_item(
+        self,
+        identifier: str,
+    ) -> AnyExtractedModel:
+        """Return one extracted item for the given `identifier`.
+
+        Args:
+            identifier: The extracted item's identifier
+
+        Raises:
+            HTTPError: If no extracted item was found
+
+        Returns:
+            A single extracted item
+        """
+        response = self.request(
+            method="GET",
+            endpoint=f"extracted-item/{identifier}",
+        )
+        return ExtractedModelTypeAdapter.validate_python(response)
 
     def fetch_merged_items(  # noqa: PLR0913
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mex-common"
-version = "0.63.0"
+version = "0.64.0"
 description = "Common library for MEx python projects."
 authors = [{ name = "MEx Team", email = "mex@rki.de" }]
 readme = { file = "README.md", content-type = "text/markdown" }

--- a/tests/backend_api/test_connector.py
+++ b/tests/backend_api/test_connector.py
@@ -88,6 +88,29 @@ def test_fetch_extracted_items_mocked(
     )
 
 
+def test_get_extracted_item_mocked(
+    mocked_backend: MagicMock, extracted_person: ExtractedPerson
+) -> None:
+    mocked_return = extracted_person.model_dump()
+    mocked_backend.return_value.json.return_value = mocked_return
+
+    connector = BackendApiConnector.get()
+    response = connector.get_extracted_item("e3VhxMhEKyjqN5flzLpiEB")
+
+    assert response == extracted_person
+
+    assert mocked_backend.call_args == call(
+        "GET",
+        "http://localhost:8080/v0/extracted-item/e3VhxMhEKyjqN5flzLpiEB",
+        None,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "rki/mex",
+        },
+        timeout=10,
+    )
+
+
 def test_fetch_merged_items_mocked(
     mocked_backend: MagicMock, merged_person: MergedPerson
 ) -> None:


### PR DESCRIPTION

### Added

- add identifier filter to merged and preview fetch endpoints in BackendApiConnector
- add `fetch_all_merged_items` and `get_extracted_item` methods to BackendApiConnector

### Changes

- BREAKING: replace hadPrimarySource with reference field filter in BackendApiConnector
- BREAKING: BackendApiConnector fetch endpoint methods now expect keyword arguments

