### PR TITLE
feature/blake2 pickle hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 - BREAKING: change validation argument of `create_merged_item` helper
+- BREAKING: change model hash and string computation to faster black2/pickle
 
 ### Deprecated
 
 ### Removed
+
+- BREAKING: remove unused `BaseModel.checksum` method
 
 ### Fixed
 

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -140,17 +140,9 @@ class DummyBaseModel(BaseModel):
     foo: str | None = None
 
 
-def test_base_model_checksum() -> None:
-    model_1 = DummyBaseModel()
-    assert model_1.checksum() == "da8e081aa63fd2fd5b909dd86c6dfa6c"
-
-    model_2 = DummyBaseModel(foo="bar")
-    assert model_1.checksum() != model_2.checksum()
-
-
 def test_base_model_str() -> None:
     model = DummyBaseModel(foo="bar")
-    assert str(model) == "DummyBaseModel: 94232c5b8fc9272f6f73a1e36eb68fcf"
+    assert str(model) == "DummyBaseModel(hash='0xf824b9416780b5f')"
 
 
 def test_base_model_hash() -> None:
@@ -158,5 +150,6 @@ def test_base_model_hash() -> None:
     thing2 = DummyBaseModel(foo="4567")
     thing3 = DummyBaseModel(foo="5678")
 
+    assert hash(thing1) == 2305511607198672667
     assert hash(thing1) == hash(thing2)
     assert hash(thing1) != hash(thing3)


### PR DESCRIPTION
### PR Context
- this PR improves the speed of hashing and stringifying models
  - pickle is faster than json for serializing
  - blake2 is faster than md5 for hashing

### Changes
- BREAKING: change model hash and string computation to faster black2/pickle

### Removed

- BREAKING: remove unused `BaseModel.checksum` method