### PR TITLE
feature/clean up tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - bumped pytz to newest version >=2025
 
 ### Changes
+
+- don't require env settings for ldap and wiki tests
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
 - fixed temporal entity tests for newest pytz version
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,7 +201,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added MEX_BACKEND_API_PARALLELIZATION and MEX_BACKEND_API_CHUNK_SIZE settings
 - added support for sending batches of data to the backend in parallel
 
-
 ### Changes
 
 - bump cookiecutter template to ed5deb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ addopts = [
     "--cov",
     "--no-cov-on-fail",
     "--cov-report=term-missing:skip-covered",
-    "--cov-fail-under=95",
+    "--cov-fail-under=96",
     "--cov-branch",
     "--pdbcls=IPython.terminal.debugger:TerminalPdb",
     "--random-order-bucket=global",

--- a/tests/connector/test_base.py
+++ b/tests/connector/test_base.py
@@ -5,6 +5,9 @@ class DummyConnector(BaseConnector):
     def __init__(self) -> None:
         self.closed = False
 
+    def metrics(self) -> dict[str, int]:
+        return {"foo": 42}
+
     def close(self) -> None:
         self.closed = True
 
@@ -28,3 +31,13 @@ def test_connector_store_reset() -> None:
 
     assert connector.closed is True
     assert len(list(CONNECTOR_STORE)) == 0
+
+
+def test_connector_store_metrics() -> None:
+    DummyConnector.get()
+    assert len(list(CONNECTOR_STORE)) == 1
+
+    assert CONNECTOR_STORE.metrics() == {"dummy_connector_foo": 42}
+
+    CONNECTOR_STORE.reset()
+    assert CONNECTOR_STORE.metrics() == {}

--- a/tests/identity/test_memory.py
+++ b/tests/identity/test_memory.py
@@ -92,3 +92,15 @@ def test_fetch_found() -> None:
 
     # we get a match again
     assert identities == [identity]
+
+
+def test_metrics() -> None:
+    provider = MemoryIdentityProvider.get()
+    had_primary_source = MergedPrimarySourceIdentifier("00000000000000")
+    assert provider.metrics() == {"database_size": 1}
+
+    provider.assign(had_primary_source, "thing-X")
+    assert provider.metrics() == {"database_size": 2}
+
+    provider.assign(had_primary_source, "thing-Y")
+    assert provider.metrics() == {"database_size": 3}

--- a/tests/ldap/conftest.py
+++ b/tests/ldap/conftest.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, Mock
 
 import pytest
 from ldap3 import Connection
+from ldap3.core.exceptions import LDAPSocketOpenError
 from pytest import MonkeyPatch
 
 from mex.common.ldap.connector import LDAPConnector
@@ -58,3 +59,14 @@ def ldap_mocker(monkeypatch: MonkeyPatch) -> LDAPMocker:
         monkeypatch.setattr(LDAPConnector, "__init__", __init__)
 
     return mocker
+
+
+@pytest.fixture(autouse=True)
+def skip_ldap_integration_tests_on_connection_error(
+    is_integration_test: bool,  # noqa: FBT001
+) -> None:
+    if is_integration_test:
+        try:
+            LDAPConnector.get()
+        except LDAPSocketOpenError:
+            pytest.skip("LDAP unavailable")

--- a/tests/ldap/test_transform.py
+++ b/tests/ldap/test_transform.py
@@ -244,6 +244,7 @@ def test_analyse_person_string(string: str, expected: list[PersonName]) -> None:
 def test_transform_ldap_persons_with_query_to_extracted_persons(
     extracted_primary_sources: dict[str, ExtractedPrimarySource],
     extracted_unit: ExtractedOrganizationalUnit,
+    extracted_organization_rki: ExtractedOrganization,
 ) -> None:
     ldap_person = LDAPPerson.model_validate(SAMPLE_PERSON_ATTRS)
     ldap_persons_with_query = [LDAPPersonWithQuery(person=ldap_person, query="test")]
@@ -252,13 +253,14 @@ def test_transform_ldap_persons_with_query_to_extracted_persons(
         ldap_persons_with_query,
         extracted_primary_sources["ldap"],
         [extracted_unit],
+        extracted_organization_rki,
     )
 
     assert len(extracted_persons) == 1
     assert extracted_persons[0].model_dump() == {
         "hadPrimarySource": "ebs5siX85RkdrhBRlsYgRP",
         "identifierInPrimarySource": "00000000-0000-4000-8000-000000000000",
-        "affiliation": [],
+        "affiliation": [extracted_organization_rki.stableTargetId],
         "email": ["SampleS@mail.tld"],
         "familyName": ["Sample"],
         "fullName": ["Sample, Sam"],

--- a/tests/ldap/test_transform.py
+++ b/tests/ldap/test_transform.py
@@ -258,7 +258,7 @@ def test_transform_ldap_persons_with_query_to_extracted_persons(
 
     assert len(extracted_persons) == 1
     assert extracted_persons[0].model_dump() == {
-        "hadPrimarySource": "ebs5siX85RkdrhBRlsYgRP",
+        "hadPrimarySource": extracted_primary_sources["ldap"].stableTargetId,
         "identifierInPrimarySource": "00000000-0000-4000-8000-000000000000",
         "affiliation": [extracted_organization_rki.stableTargetId],
         "email": ["SampleS@mail.tld"],

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mex.common.context import SingleSingletonStore
+from mex.common.context import SingleSingletonStore, SingletonStore
 
 
 class Parent:
@@ -9,6 +9,21 @@ class Parent:
 
 class Child(Parent):
     pass
+
+
+def test_singleton_store() -> None:
+    store = SingletonStore["Parent"]()
+    parent = store.load(Parent)
+
+    popped = store.pop(Parent)
+    assert popped is parent
+
+    new_parent = store.load(Parent)
+    assert new_parent is not parent
+
+    store.reset()
+
+    assert not store._instances_by_class
 
 
 def test_single_singleton_store() -> None:

--- a/tests/wikidata/conftest.py
+++ b/tests/wikidata/conftest.py
@@ -5,6 +5,7 @@ import pytest
 import requests
 from pytest import MonkeyPatch
 
+from mex.common.settings import BaseSettings
 from mex.common.wikidata.connector import WikidataAPIConnector
 
 TESTDATA_DIR = Path(__file__).parent / "test_data"
@@ -20,3 +21,18 @@ def mocked_session_wikidata_api(monkeypatch: MonkeyPatch) -> MagicMock:
 
     monkeypatch.setattr(WikidataAPIConnector, "__init__", __init__)
     return mocked_session
+
+
+@pytest.fixture(autouse=True)
+def set_wiki_api_url_for_integration_tests(
+    monkeypatch: MonkeyPatch,
+    is_integration_test: bool,  # noqa: FBT001
+) -> None:
+    """Set correct Wikidata API URL for integration tests."""
+    if is_integration_test:
+        settings = BaseSettings.get()
+        monkeypatch.setattr(
+            settings,
+            "wiki_api_url",
+            "https://www.wikidata.org/w/api.php",
+        )


### PR DESCRIPTION
### PR Context

- cleaning up tests so `make test` runs on a fresh clone without preconditions
- close some coverage gaps

### Changes

- don't require env settings for ldap and wiki tests