### PR TITLE
Feature/mx 2118 split mex ops and mex assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **BREAKING** add configuration parameter `ops_dir`. Settings are now read from `ops_dir/config/.env` and `ops_dir/config/secrets/*`. Make sure your environment variable `MEX_OPS_DIR` points to your local mex-ops directory.
+- **BREAKING** add configuration parameter `ops_dir`. Settings are now read from
+  `ops_dir/config/.env` and `ops_dir/config/secrets/*`. Make sure your environment
+  variable `MEX_OPS_DIR` points to your local mex-ops directory.
+  For dependent repositories: change the type of your Settings parameters that point to
+  migrated files (e.g. certificates) to `OpsPath`.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **BREAKING** add configuration parameter `ops_dir`. Settings are now read from `ops_dir/config/.env` and `ops_dir/config/secrets/*`. Make sure your environment variable `MEX_OPS_DIR` points to your local mex-ops directory.
+
 ### Changes
 
 ### Deprecated

--- a/mex/common/ldap/connector.py
+++ b/mex/common/ldap/connector.py
@@ -27,7 +27,6 @@ from mex.common.ldap.models import (
 from mex.common.logging import logger
 from mex.common.models.base.container import PaginatedItemsContainer
 from mex.common.settings import BaseSettings
-from mex.common.types import AssetsPath
 
 LDAP_FETCH_CACHE_SIZE = 5000
 
@@ -49,9 +48,9 @@ class LDAPConnector(BaseConnector):
         host = str(url.hostname)
         port = int(url.port) if url.port else None
         ca_certs_file = (
-            settings.verify_session
-            if isinstance(settings.verify_session, AssetsPath)
-            else None
+            None
+            if isinstance(settings.verify_session, bool)
+            else settings.verify_session
         )
         tls_configuration = Tls(
             validate=ssl.CERT_REQUIRED,

--- a/mex/common/settings.py
+++ b/mex/common/settings.py
@@ -13,10 +13,19 @@ from tabulate import tabulate
 
 from mex.common.context import SingleSingletonStore
 from mex.common.logging import logger
-from mex.common.types import AssetsPath, IdentityProvider, Sink, WorkPath
+from mex.common.types import (
+    AssetsPath,
+    IdentityProvider,
+    OpsPath,
+    PathWrapper,
+    Sink,
+    WorkPath,
+)
 
 SETTINGS_STORE = SingleSingletonStore["BaseSettings"]()
 MEX_ASSETS_DIR = "MEX_ASSETS_DIR"
+MEX_OPS_DIR = "MEX_OPS_DIR"
+MEX_WORK_DIR = "MEX_WORK_DIR"
 
 
 class BaseSettings(PydanticBaseSettings):
@@ -55,14 +64,14 @@ class BaseSettings(PydanticBaseSettings):
         **values: Any,  # noqa: ANN401
     ) -> None:
         """Construct a new settings instance."""
-        if assets_dir := environ.get(MEX_ASSETS_DIR):
-            if not _env_file or _env_file is ENV_FILE_SENTINEL:
-                _env_file = [
-                    Path(assets_dir, ".env"),  # bw-compat
-                    Path(assets_dir, "config", ".env"),
-                ]
+        if ops_dir := environ.get(MEX_OPS_DIR):
+            env_file_argument_is_not_set = (
+                _env_file is None or _env_file is ENV_FILE_SENTINEL
+            )
+            if env_file_argument_is_not_set:
+                _env_file = [Path(ops_dir, "config", ".env")]
             if not _secrets_dir:
-                _secrets_dir = Path(assets_dir, "config", "secrets")
+                _secrets_dir = Path(ops_dir, "config", "secrets")
         super().__init__(
             _env_file=_env_file,
             _env_file_encoding=_env_file_encoding,
@@ -107,13 +116,21 @@ class BaseSettings(PydanticBaseSettings):
         ),
         validation_alias=MEX_ASSETS_DIR,
     )
+    ops_dir: Path = Field(
+        Path.cwd() / "ops",
+        description=(
+            "Path to directory that contains configuration files, "
+            "looks for a folder named `ops` in the current directory by default."
+        ),
+        validation_alias=MEX_OPS_DIR,
+    )
     work_dir: Path = Field(
         Path.cwd(),
         description=(
             "Path to directory that stores generated and temporary files. "
             "Defaults to the current working directory."
         ),
-        validation_alias="MEX_WORK_DIR",
+        validation_alias=MEX_WORK_DIR,
     )
     identity_provider: IdentityProvider = Field(
         IdentityProvider.MEMORY,
@@ -142,12 +159,12 @@ class BaseSettings(PydanticBaseSettings):
         description="How many items to load into the backend in one chunk.",
         validation_alias="MEX_BACKEND_API_CHUNK_SIZE",
     )
-    verify_session: bool | AssetsPath = Field(
+    verify_session: bool | OpsPath = Field(
         True,  # noqa: FBT003
         description=(
             "Either a boolean that controls whether we verify the server's TLS "
             "certificate, or a path to a CA bundle to use. If a path is given, it can "
-            "be either absolute or relative to the `assets_dir`. Defaults to True."
+            "be either absolute or relative to the `ops_dir`. Defaults to True."
         ),
         validation_alias="MEX_VERIFY_SESSION",
     )
@@ -243,14 +260,21 @@ class BaseSettings(PydanticBaseSettings):
 
     @model_validator(mode="after")
     def resolve_paths(self) -> Self:
-        """Resolve AssetPath and WorkPath."""
+        """Resolve AssetPath, OpsPath, and WorkPath."""
 
         def _resolve(model: PydanticBaseModel, _name: str) -> None:
             value = getattr(model, _name)
-            if isinstance(value, AssetsPath) and value.is_relative():
-                object.__setattr__(model, _name, self.assets_dir.resolve() / value)
-            elif isinstance(value, WorkPath) and value.is_relative():
-                object.__setattr__(model, _name, self.work_dir.resolve() / value)
+            if isinstance(value, PathWrapper) and value.is_relative():
+                if isinstance(value, AssetsPath):
+                    resolved_path = self.assets_dir.resolve() / value
+                elif isinstance(value, OpsPath):
+                    resolved_path = self.ops_dir.resolve() / value
+                elif isinstance(value, WorkPath):
+                    resolved_path = self.work_dir.resolve() / value
+                else:
+                    msg = f"Unexpected path type: {type(value)}"
+                    raise ValueError(msg)
+                object.__setattr__(model, _name, resolved_path)
             elif isinstance(value, PydanticBaseModel):
                 for sub_model_field_name in type(value).model_fields:
                     _resolve(value, sub_model_field_name)

--- a/mex/common/settings.py
+++ b/mex/common/settings.py
@@ -273,7 +273,7 @@ class BaseSettings(PydanticBaseSettings):
                     resolved_path = self.work_dir.resolve() / value
                 else:
                     msg = f"Unexpected path type: {type(value)}"
-                    raise ValueError(msg)
+                    raise RuntimeError(msg)
                 object.__setattr__(model, _name, resolved_path)
             elif isinstance(value, PydanticBaseModel):
                 for sub_model_field_name in type(value).model_fields:

--- a/mex/common/testing/plugin.py
+++ b/mex/common/testing/plugin.py
@@ -25,7 +25,13 @@ from mex.common.primary_source.extract import extract_seed_primary_sources
 from mex.common.primary_source.transform import (
     transform_seed_primary_sources_to_extracted_primary_sources,
 )
-from mex.common.settings import SETTINGS_STORE, BaseSettings
+from mex.common.settings import (
+    MEX_ASSETS_DIR,
+    MEX_OPS_DIR,
+    MEX_WORK_DIR,
+    SETTINGS_STORE,
+    BaseSettings,
+)
 from mex.common.types import MergedPrimarySourceIdentifier
 from mex.common.wikidata.connector import WikidataAPIConnector
 from mex.common.wikidata.models import WikidataOrganization
@@ -57,19 +63,20 @@ def patch_reprs(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
-def isolate_assets_dir(
+def isolate_assets_and_ops_dir(
     is_integration_test: bool,  # noqa: FBT001
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Disable the `MEX_ASSETS_DIR` environment variable for unit testing."""
+    """Disable assets and ops dir environment variables for unit testing."""
     if not is_integration_test:  # pragma: no cover
-        monkeypatch.delenv("MEX_ASSETS_DIR", raising=False)
+        monkeypatch.delenv(MEX_ASSETS_DIR, raising=False)
+        monkeypatch.delenv(MEX_OPS_DIR, raising=False)
 
 
 @pytest.fixture(autouse=True)
 def isolate_work_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Set the `MEX_WORK_DIR` environment variable to a temp path for all tests."""
-    monkeypatch.setenv("MEX_WORK_DIR", str(tmp_path))
+    monkeypatch.setenv(MEX_WORK_DIR, str(tmp_path))
 
 
 @pytest.fixture(autouse=True)
@@ -80,7 +87,7 @@ def settings() -> BaseSettings:
 
 @pytest.fixture(autouse=True)
 def isolate_settings(
-    isolate_assets_dir: None,  # noqa: ARG001
+    isolate_assets_and_ops_dir: None,  # noqa: ARG001
     isolate_work_dir: None,  # noqa: ARG001
 ) -> Generator[None, None, None]:
     """Automatically reset the settings singleton store."""

--- a/mex/common/types/__init__.py
+++ b/mex/common/types/__init__.py
@@ -34,7 +34,7 @@ from mex.common.types.identifier import (
 )
 from mex.common.types.identity import IdentityProvider
 from mex.common.types.link import Link, LinkLanguage
-from mex.common.types.path import AssetsPath, PathWrapper, WorkPath
+from mex.common.types.path import AssetsPath, OpsPath, PathWrapper, WorkPath
 from mex.common.types.sink import Sink
 from mex.common.types.temporal_entity import (
     CET,
@@ -140,6 +140,7 @@ __all__ = (
     "MergedResourceIdentifier",
     "MergedVariableGroupIdentifier",
     "MergedVariableIdentifier",
+    "OpsPath",
     "PathWrapper",
     "PersonalData",
     "ResourceCreationMethod",

--- a/mex/common/types/path.py
+++ b/mex/common/types/path.py
@@ -76,5 +76,9 @@ class AssetsPath(PathWrapper):
     """Custom path for settings that can be absolute or relative to `assets_dir`."""
 
 
+class OpsPath(PathWrapper):
+    """Custom path for settings that can be absolute or relative to `ops_dir`."""
+
+
 class WorkPath(PathWrapper):
     """Custom path for settings that can be absolute or relative to `work_dir`."""

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 from mex.common.models import BaseModel
 from mex.common.settings import SETTINGS_STORE, BaseSettings
 from mex.common.types import AssetsPath, WorkPath
+from mex.common.types.path import OpsPath
 
 
 def test_debug_setting() -> None:
@@ -63,9 +64,15 @@ def test_settings_getting_caches_singleton() -> None:
 @pytest.mark.integration
 def test_parse_env_file() -> None:
     settings = BaseSettings.get()
-    # "work_dir" and "assets_dir" are always set, assert that more than these two are
-    # set. This indicates an .env file was found and at least one setting was parsed.
-    assert settings.model_fields_set != {"work_dir", "assets_dir"}
+    # "assets_dir", "ops_dir", and "work_dir" are always set, assert that more than
+    # these two are set. This indicates an .env file was found and at least one
+    # setting was parsed.
+    model_fields_set_from_env_file = settings.model_fields_set - {
+        "assets_dir",
+        "ops_dir",
+        "work_dir",
+    }
+    assert model_fields_set_from_env_file
 
 
 class SubModel(BaseModel):
@@ -76,6 +83,7 @@ class DummySettings(BaseSettings):
     non_path: str
     abs_work_path: WorkPath
     rel_work_path: WorkPath
+    rel_ops_path: OpsPath
     assets_path: AssetsPath
     sub_model: SubModel
 
@@ -92,8 +100,10 @@ def test_resolve_paths() -> None:
         non_path="blablabla",
         abs_work_path=absolute,
         rel_work_path=relative,
+        rel_ops_path=relative,
         assets_path=AssetsPath(relative),
         assets_dir=Path(absolute / "assets_dir"),
+        ops_dir=Path(absolute / "ops_dir"),
         work_dir=Path(absolute / "work_dir"),
         sub_model=SubModel(sub_model_path=relative),
     )
@@ -101,6 +111,7 @@ def test_resolve_paths() -> None:
     assert settings.non_path == "blablabla"
     assert settings.abs_work_path == absolute
     assert settings.rel_work_path == WorkPath(settings.work_dir / relative)
+    assert settings.rel_ops_path == OpsPath(settings.ops_dir / relative)
     assert settings.assets_path == AssetsPath(absolute / "assets_dir" / relative)
     assert settings.sub_model.sub_model_path == WorkPath(settings.work_dir / relative)
 


### PR DESCRIPTION
To test this, first checkout mex-ops PR 1.

### Added
<!-- New features and interfaces -->
- **BREAKING** add configuration parameter `ops_dir`. Settings are now read from
  `ops_dir/config/.env` and `ops_dir/config/secrets/*`. Make sure your environment
  variable `MEX_OPS_DIR` points to your local mex-ops directory.
  For dependent repositories: change the type of your Settings parameters that point to
  migrated files (e.g. certificates) to `OpsPath`.
