### PR TITLE
Bump cookiecutter template to 5c0569

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "checkout": null,
-  "commit": "57105a14fe4ad7aff83c0b10d523bb19fe1f4bdd",
+  "commit": "5c0569f9f52ff356e9ebfd48119ede41bc47a8a1",
   "context": {
     "cookiecutter": {
       "project_name": "common",
       "short_summary": "Common library for MEx python projects.",
       "long_summary": "The `mex-common` library is a software development toolkit that is used by multiple components within the MEx project. It contains utilities for building pipelines like a common commandline interface, logging and configuration setup. It also provides common auxiliary connectors that can be used to fetch data from external services and a re-usable implementation of the MEx metadata schema as pydantic models.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "57105a14fe4ad7aff83c0b10d523bb19fe1f4bdd"
+      "_commit": "5c0569f9f52ff356e9ebfd48119ede41bc47a8a1"
     }
   },
   "directory": null,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- updated template to https://github.com/robert-koch-institut/mex-template/commit/5c0569
+
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/57105a
 
 ### Deprecated


### PR DESCRIPTION
### Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/5c0569

### Conflicts

```diff
diff a/.github/workflows/release.yml b/.github/workflows/release.yml	(rejected hunks)
@@ -102,15 +102,48 @@ jobs:
           password: ${{secrets.GITHUB_TOKEN}}
 
       - name: Build, tag and push docker image
+        id: push_step
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v.7.1.0
         env:
           IMAGE: ghcr.io/${{ github.repository }}
           TAG: ${{ needs.release.outputs.tag }}
+        with:
+          push: true
+          tags: |
+            ${IMAGE}:latest
+            ${IMAGE}:${{ github.sha }}
+            ${IMAGE}:${TAG}
+          outputs: type=image,oci-mediatypes=true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: 'v2.4.1'
+
+      - name: Sign docker images
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}
+          DIGEST: ${{ steps.push_step.outputs.digest }}
+          BASE64_PRIV_KEY: ${{ secrets.MEX_SIGNING_KEY }}
+          COSIGN_PASSWORD: ""
+          BASE64_PUB_KEY: ${{ vars.MEX_SIGNING_PUB }}
+          COSIGN_DOCKER_MEDIA_TYPES: 1
         run: |
-          docker build . \
-          --tag ${IMAGE}:latest \
-          --tag ${IMAGE}:${{ github.sha }} \
-          --tag ${IMAGE}:${TAG}
-          docker push --all-tags ${IMAGE}
+          set -e # exit on first error
+
+          # signing
+          echo "Signing Image: ${IMAGE}@${DIGEST}"
+          export COSIGN_PRIVATE_KEY=$(echo "$BASE64_PRIV_KEY" | base64 --decode)
+          cosign sign --yes --registry-referrers-mode=legacy --key env://COSIGN_PRIVATE_KEY ${IMAGE}@${DIGEST}
+          echo "Signature generated successfully"
+
+          # smoke test
+          echo "Verifying signature"
+          trap 'rm -f temp_ssh_id.pub cosign.pub' EXIT
+          echo "$BASE64_PUB_KEY" | base64 --decode > temp_ssh_id.pub
+          ssh-keygen -e -m PKCS8 -f temp_ssh_id.pub > cosign.pub
+          cosign verify --key cosign.pub "${IMAGE}@${DIGEST}"
+          echo "Signature verified successfully"
 
   distribute:
     runs-on: ubuntu-latest
```

```diff
diff a/README.md b/README.md	(rejected hunks)
@@ -92,6 +92,23 @@ components of the MEx project are open-sourced under the same license as well.
 - run directly using docker `make run`
 - start with docker compose `make start`
 
+### Container verification
+
+Images released to GHCR are signed using [cosign](https://github.com/sigstore/cosign).
+
+Verification is handled by our deployment using the organization's public key.
+To verify an image manually:
+1. install `cosign` on your system
+2. obtain the organization's public key
+3. run the following command:
+   ```bash
+   cosign verify --key cosign.pub ghcr.io/robert-koch-institut/mex-common:<TAG>
+   ```
+
+To set up signing for a new project:
+1. ensure the organization-wide private key is available in a GitHub Secret named `MEX_SIGNING_KEY`
+2. ensure the organization-wide public key is available in a GitHub Variable named `MEX_SIGNING_PUB`
+
 ## Commands
 
 - run `uv run {command} --help` to print instructions
```
