### PR TITLE
feature/update backend_api connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- make `ensure_rule_set` in `mex.common.merged.main` public
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- add `reference_filters` argument to `fetch_*_items` methods of `BackendApiConnector`,
+  using POST `_search` endpoints when needed, otherwise sticking with GET
+- add `fetch_all_extracted_items` to `BackendApiConnector` for completeness sake
+
 ### Changes
 
 ### Deprecated
 
 ### Removed
+
+- BREAKING: remove `search_preview_items` from `BackendApiConnector`,
+  use `fetch_preview_items(reference_filters=...)` instead
+- BREAKING: drop the deprecated `referenced_identifier`, `reference_field` and
+  `stable_target_id` search arguments, use `reference_filters` instead
 
 ### Fixed
 

--- a/mex/common/backend_api/connector.py
+++ b/mex/common/backend_api/connector.py
@@ -1,6 +1,8 @@
-from collections.abc import Generator
-from typing import Any, TypeVar
+from collections.abc import Callable, Generator
+from typing import Annotated, Any, TypeVar
 from urllib.parse import urljoin
+
+from pydantic import Field
 
 from mex.common.connector import HTTPConnector
 from mex.common.identity.models import Identity
@@ -35,13 +37,14 @@ from mex.common.types import (
 _IngestibleModelT = TypeVar(
     "_IngestibleModelT", bound=AnyExtractedModel | AnyRuleSetResponse
 )
+_ContainerItemT = TypeVar("_ContainerItemT")
 
 
 class ReferenceFilter(BaseModel):
     """Reference filter definition with a field and list of identifiers."""
 
     field: str
-    identifiers: list[str]
+    identifiers: Annotated[list[Identifier | None], Field(min_length=1, max_length=100)]
 
 
 class BackendApiConnector(HTTPConnector):
@@ -63,25 +66,82 @@ class BackendApiConnector(HTTPConnector):
         settings = BaseSettings.get()
         self.url = urljoin(str(settings.backend_api_url), self.API_VERSION)
 
-    def fetch_extracted_items(  # noqa: PLR0913
+    @staticmethod
+    def _fetch_all_items(
+        fetch_page: Callable[[int, int], PaginatedItemsContainer[_ContainerItemT]],
+    ) -> Generator[_ContainerItemT, None, None]:
+        """Yield all items across all pages using the given page-fetching callable.
+
+        Args:
+            fetch_page: Callable that returns one page given a `skip` and a `limit`
+
+        Returns:
+            Generator for all items across all matching pages
+        """
+        total_item_number = fetch_page(0, 1).total
+        item_number_limit = 100  # 100 is the maximum possible number per get-request
+        for item_counter in range(0, total_item_number, item_number_limit):
+            yield from fetch_page(item_counter, item_number_limit).items
+
+    @staticmethod
+    def _search_request(
+        endpoint: str,
+        filters: dict[str, Any],
+        reference_filters: list[ReferenceFilter] | None,
+        skip: int,
+        limit: int,
+    ) -> dict[str, Any]:
+        """Build `request` kwargs for a simple GET or an advanced POST `_search`.
+
+        When `reference_filters` are given, an advanced POST search request against the
+        `_search` endpoint is built, otherwise a simple GET request with the `filters`
+        passed as query params.
+
+        Args:
+            endpoint: Base endpoint of the resource, e.g. `merged-item`
+            filters: Simple filters shared by the GET params and the POST body
+            reference_filters: Advanced reference filters to search for
+            skip: How many items to skip for pagination
+            limit: How many items to return in one page
+
+        Returns:
+            Keyword arguments to pass to `self.request`
+        """
+        if reference_filters:
+            return {
+                "method": "POST",
+                "endpoint": f"{endpoint}/_search",
+                "payload": {
+                    **filters,
+                    "referenceFilters": reference_filters,
+                    "skip": skip,
+                    "limit": limit,
+                },
+            }
+        return {
+            "method": "GET",
+            "endpoint": endpoint,
+            "params": {**filters, "skip": str(skip), "limit": str(limit)},
+        }
+
+    def fetch_extracted_items(
         self,
         *,
         query_string: str | None = None,
-        stable_target_id: str | None = None,
         entity_type: list[str] | None = None,
-        referenced_identifier: list[str] | None = None,
-        reference_field: str | None = None,
+        reference_filters: list[ReferenceFilter] | None = None,
         skip: int = 0,
         limit: int = 100,
     ) -> PaginatedItemsContainer[AnyExtractedModel]:
         """Fetch extracted items that match the given set of filters.
 
+        When `reference_filters` are given, the advanced POST search endpoint is used,
+        otherwise the simple GET endpoint is queried.
+
         Args:
             query_string: Full-text search query
-            stable_target_id: The item's stableTargetId
             entity_type: The item's entityType
-            referenced_identifier: Merged item identifiers filter
-            reference_field: Field name to filter for
+            reference_filters: Advanced reference filters to search for
             skip: How many items to skip for pagination
             limit: How many items to return in one page
 
@@ -92,19 +152,45 @@ class BackendApiConnector(HTTPConnector):
             One page of extracted items and the total count that was matched
         """
         response = self.request(
-            method="GET",
-            endpoint="extracted-item",
-            params={
-                "q": query_string,
-                "stableTargetId": stable_target_id,
-                "entityType": entity_type,
-                "referencedIdentifier": referenced_identifier,
-                "referenceField": reference_field,
-                "skip": str(skip),
-                "limit": str(limit),
-            },
+            **self._search_request(
+                "extracted-item",
+                {"q": query_string, "entityType": entity_type},
+                reference_filters,
+                skip,
+                limit,
+            )
         )
         return PaginatedItemsContainer[AnyExtractedModel].model_validate(response)
+
+    def fetch_all_extracted_items(
+        self,
+        *,
+        query_string: str | None = None,
+        entity_type: list[str] | None = None,
+        reference_filters: list[ReferenceFilter] | None = None,
+    ) -> Generator[AnyExtractedModel, None, None]:
+        """Fetch all extracted items that match the given set of filters.
+
+        Args:
+            query_string: Full-text search query
+            entity_type: The item's entityType
+            reference_filters: Advanced reference filters to search for
+
+        Raises:
+            HTTPError: If search was not accepted, crashes or times out
+
+        Returns:
+            Generator for all extracted items that match the filters
+        """
+        return self._fetch_all_items(
+            lambda skip, limit: self.fetch_extracted_items(
+                query_string=query_string,
+                entity_type=entity_type,
+                reference_filters=reference_filters,
+                skip=skip,
+                limit=limit,
+            )
+        )
 
     def get_extracted_item(
         self,
@@ -133,19 +219,20 @@ class BackendApiConnector(HTTPConnector):
         query_string: str | None = None,
         identifier: str | None = None,
         entity_type: list[str] | None = None,
-        referenced_identifier: list[str] | None = None,
-        reference_field: str | None = None,
+        reference_filters: list[ReferenceFilter] | None = None,
         skip: int = 0,
         limit: int = 100,
     ) -> PaginatedItemsContainer[AnyMergedModel]:
         """Fetch merged items that match the given set of filters.
 
+        When `reference_filters` are given, the advanced POST search endpoint is used,
+        otherwise the simple GET endpoint is queried.
+
         Args:
             query_string: Full-text search query
             identifier: Merged item identifier filter
             entity_type: The items' entityType
-            referenced_identifier: Merged item identifiers filter
-            reference_field: Field name to filter for
+            reference_filters: Advanced reference filters to search for
             skip: How many items to skip for pagination
             limit: How many items to return in one page
 
@@ -156,17 +243,17 @@ class BackendApiConnector(HTTPConnector):
             One page of merged items and the total count that was matched
         """
         response = self.request(
-            method="GET",
-            endpoint="merged-item",
-            params={
-                "q": query_string,
-                "identifier": identifier,
-                "entityType": entity_type,
-                "referencedIdentifier": referenced_identifier,
-                "referenceField": reference_field,
-                "skip": str(skip),
-                "limit": str(limit),
-            },
+            **self._search_request(
+                "merged-item",
+                {
+                    "q": query_string,
+                    "identifier": identifier,
+                    "entityType": entity_type,
+                },
+                reference_filters,
+                skip,
+                limit,
+            )
         )
         return PaginatedItemsContainer[AnyMergedModel].model_validate(response)
 
@@ -176,8 +263,7 @@ class BackendApiConnector(HTTPConnector):
         query_string: str | None = None,
         identifier: str | None = None,
         entity_type: list[str] | None = None,
-        referenced_identifier: list[str] | None = None,
-        reference_field: str | None = None,
+        reference_filters: list[ReferenceFilter] | None = None,
     ) -> Generator[AnyMergedModel, None, None]:
         """Fetch all merged items that match the given set of filters.
 
@@ -185,8 +271,7 @@ class BackendApiConnector(HTTPConnector):
             query_string: Full-text search query
             identifier: Merged item identifier filter
             entity_type: The items' entityType
-            referenced_identifier: Merged item identifiers filter
-            reference_field: Field name to filter for
+            reference_filters: Advanced reference filters to search for
 
         Raises:
             HTTPError: If search was not accepted, crashes or times out
@@ -194,28 +279,16 @@ class BackendApiConnector(HTTPConnector):
         Returns:
             Generator for all merged items that match the filters
         """
-        response = self.fetch_merged_items(
-            query_string=query_string,
-            identifier=identifier,
-            entity_type=entity_type,
-            referenced_identifier=referenced_identifier,
-            reference_field=reference_field,
-            skip=0,
-            limit=1,
-        )
-        total_item_number = response.total
-        item_number_limit = 100  # 100 is the maximum possible number per get-request
-        for item_counter in range(0, total_item_number, item_number_limit):
-            response = self.fetch_merged_items(
+        return self._fetch_all_items(
+            lambda skip, limit: self.fetch_merged_items(
                 query_string=query_string,
                 identifier=identifier,
                 entity_type=entity_type,
-                referenced_identifier=referenced_identifier,
-                reference_field=reference_field,
-                skip=item_counter,
-                limit=item_number_limit,
+                reference_filters=reference_filters,
+                skip=skip,
+                limit=limit,
             )
-            yield from response.items
+        )
 
     def get_merged_item(
         self,
@@ -244,19 +317,20 @@ class BackendApiConnector(HTTPConnector):
         query_string: str | None = None,
         identifier: str | None = None,
         entity_type: list[str] | None = None,
-        referenced_identifier: list[str] | None = None,
-        reference_field: str | None = None,
+        reference_filters: list[ReferenceFilter] | None = None,
         skip: int = 0,
         limit: int = 100,
     ) -> PaginatedItemsContainer[AnyPreviewModel]:
         """Fetch merged item previews that match the given set of filters.
 
+        When `reference_filters` are given, the advanced POST search endpoint is used,
+        otherwise the simple GET endpoint is queried.
+
         Args:
             query_string: Full-text search query
             identifier: Merged item identifier filter
             entity_type: The items' entityType
-            referenced_identifier: Merged item identifiers filter
-            reference_field: Field name to filter for
+            reference_filters: Advanced reference filters to search for
             skip: How many items to skip for pagination
             limit: How many items to return in one page
 
@@ -267,17 +341,17 @@ class BackendApiConnector(HTTPConnector):
             One page of preview items and the total count that was matched
         """
         response = self.request(
-            method="GET",
-            endpoint="preview-item",
-            params={
-                "q": query_string,
-                "identifier": identifier,
-                "entityType": entity_type,
-                "referencedIdentifier": referenced_identifier,
-                "referenceField": reference_field,
-                "skip": str(skip),
-                "limit": str(limit),
-            },
+            **self._search_request(
+                "preview-item",
+                {
+                    "q": query_string,
+                    "identifier": identifier,
+                    "entityType": entity_type,
+                },
+                reference_filters,
+                skip,
+                limit,
+            )
         )
         return PaginatedItemsContainer[AnyPreviewModel].model_validate(response)
 
@@ -302,31 +376,6 @@ class BackendApiConnector(HTTPConnector):
         )
         return PreviewModelTypeAdapter.validate_python(response)
 
-    def search_preview_items(  # noqa: PLR0913
-        self,
-        query_string: str | None = None,
-        identifier: str | None = None,
-        entity_type: list[str] | None = None,
-        references: list[ReferenceFilter] | None = None,
-        skip: int = 0,
-        limit: int = 10,
-    ) -> PaginatedItemsContainer[AnyPreviewModel]:
-        """Search for preview items with advanced filter combinations."""
-        payload = {
-            "q": query_string,
-            "identifier": identifier,
-            "entityType": entity_type,
-            "referenceFilters": references,
-            "skip": skip,
-            "limit": limit,
-        }
-        response = self.request(
-            method="POST",
-            endpoint="preview-item/_search",
-            payload=payload,
-        )
-        return PaginatedItemsContainer[AnyPreviewModel].model_validate(response)
-
     def fetch_publishable_merged_items(  # noqa: PLR0913
         self,
         *,
@@ -334,20 +383,21 @@ class BackendApiConnector(HTTPConnector):
         query_string: str | None = None,
         identifier: str | None = None,
         entity_type: list[str] | None = None,
-        referenced_identifier: list[str] | None = None,
-        reference_field: str | None = None,
+        reference_filters: list[ReferenceFilter] | None = None,
         skip: int = 0,
         limit: int = 100,
     ) -> PaginatedItemsContainer[AnyMergedModel]:
         """Fetch publishable merged items that match the given set of filters.
+
+        When `reference_filters` are given, the advanced POST search endpoint is used,
+        otherwise the simple GET endpoint is queried.
 
         Args:
             publishing_target: The target to publish the items to
             query_string: Full-text search query
             identifier: Merged item identifier filter
             entity_type: The items' entityType
-            referenced_identifier: Merged item identifiers filter
-            reference_field: Field name to filter for
+            reference_filters: Advanced reference filters to search for
             skip: How many items to skip for pagination
             limit: How many items to return in one page
 
@@ -358,30 +408,29 @@ class BackendApiConnector(HTTPConnector):
             One page of publishable merged items and the total count that was matched
         """
         response = self.request(
-            method="GET",
-            endpoint="publishable-merged-item",
-            params={
-                "publishingTarget": publishing_target,
-                "q": query_string,
-                "identifier": identifier,
-                "entityType": entity_type,
-                "referencedIdentifier": referenced_identifier,
-                "referenceField": reference_field,
-                "skip": str(skip),
-                "limit": str(limit),
-            },
+            **self._search_request(
+                "publishable-merged-item",
+                {
+                    "publishingTarget": publishing_target,
+                    "q": query_string,
+                    "identifier": identifier,
+                    "entityType": entity_type,
+                },
+                reference_filters,
+                skip,
+                limit,
+            )
         )
         return PaginatedItemsContainer[AnyMergedModel].model_validate(response)
 
-    def fetch_all_publishable_merged_items(  # noqa: PLR0913
+    def fetch_all_publishable_merged_items(
         self,
         *,
         publishing_target: str,
         query_string: str | None = None,
         identifier: str | None = None,
         entity_type: list[str] | None = None,
-        referenced_identifier: list[str] | None = None,
-        reference_field: str | None = None,
+        reference_filters: list[ReferenceFilter] | None = None,
     ) -> Generator[AnyMergedModel, None, None]:
         """Fetch all publishable merged items that match the given set of filters.
 
@@ -390,8 +439,7 @@ class BackendApiConnector(HTTPConnector):
             query_string: Full-text search query
             identifier: Merged item identifier filter
             entity_type: The items' entityType
-            referenced_identifier: Merged item identifiers filter
-            reference_field: Field name to filter for
+            reference_filters: Advanced reference filters to search for
 
         Raises:
             HTTPError: If search was not accepted, crashes or times out
@@ -399,30 +447,17 @@ class BackendApiConnector(HTTPConnector):
         Returns:
             Generator for all publishable merged items that match the filters
         """
-        response = self.fetch_publishable_merged_items(
-            publishing_target=publishing_target,
-            query_string=query_string,
-            identifier=identifier,
-            entity_type=entity_type,
-            referenced_identifier=referenced_identifier,
-            reference_field=reference_field,
-            skip=0,
-            limit=1,
-        )
-        total_item_number = response.total
-        item_number_limit = 100  # 100 is the maximum possible number per get-request
-        for item_counter in range(0, total_item_number, item_number_limit):
-            response = self.fetch_publishable_merged_items(
+        return self._fetch_all_items(
+            lambda skip, limit: self.fetch_publishable_merged_items(
                 publishing_target=publishing_target,
                 query_string=query_string,
                 identifier=identifier,
                 entity_type=entity_type,
-                referenced_identifier=referenced_identifier,
-                reference_field=reference_field,
-                skip=item_counter,
-                limit=item_number_limit,
+                reference_filters=reference_filters,
+                skip=skip,
+                limit=limit,
             )
-            yield from response.items
+        )
 
     def create_rule_set(
         self,
@@ -627,7 +662,7 @@ class BackendApiConnector(HTTPConnector):
         had_primary_source: Identifier | None = None,
         identifier_in_primary_source: str | None = None,
         stable_target_id: Identifier | None = None,
-    ) -> ItemsContainer[Identity]:
+    ) -> PaginatedItemsContainer[Identity]:
         """Find Identity instances matching the given filters.
 
         Either provide `stableTargetId` or `hadPrimarySource`
@@ -642,7 +677,7 @@ class BackendApiConnector(HTTPConnector):
                 "stableTargetId": stable_target_id,
             },
         )
-        return ItemsContainer[Identity].model_validate(response)
+        return PaginatedItemsContainer[Identity].model_validate(response)
 
     def ingest(
         self,
@@ -667,12 +702,12 @@ class BackendApiConnector(HTTPConnector):
 
     def system_status(self) -> VersionStatus:
         """Return the status and version of the backend."""
-        response = self.request(method="GET", endpoint="/_system/check")
+        response = self.request(method="GET", endpoint="_system/check")
         return VersionStatus.model_validate(response)
 
     def flush_graph(self) -> Status:
         """Flush the graph database (only for testing-backend)."""
-        response = self.request(method="DELETE", endpoint="/_system/graph")
+        response = self.request(method="DELETE", endpoint="_system/graph")
         return Status.model_validate(response)
 
 

--- a/mex/common/merged/main.py
+++ b/mex/common/merged/main.py
@@ -284,7 +284,7 @@ def _get_merged_class(
     return model_class_lookup[entity_type]
 
 
-def _ensure_rule_set(
+def ensure_rule_set(
     rule_set: AnyRuleSetRequest | AnyRuleSetResponse | None,
     stem_type: str,
 ) -> AnyRuleSetRequest | AnyRuleSetResponse:
@@ -389,7 +389,7 @@ def create_merged_item(
 
     # Get mergeable fields and ensure rule set instance
     fields = MERGEABLE_FIELDS_BY_CLASS_NAME[merged_class.__name__]
-    rule_set = _ensure_rule_set(rule_set, merged_class.stemType)
+    rule_set = ensure_rule_set(rule_set, merged_class.stemType)
 
     # Create a dictionary of merged values and set the merged identifier
     merged_dict = _create_merged_dict(fields, extracted_items, rule_set, validation)

--- a/tests/backend_api/test_connector.py
+++ b/tests/backend_api/test_connector.py
@@ -67,7 +67,6 @@ def test_fetch_extracted_items_mocked(
     connector = BackendApiConnector.get()
     response = connector.fetch_extracted_items(
         query_string="Tintzmann",
-        stable_target_id="NGwfzG8ROsrvIiQIVDVy",
         entity_type=["ExtractedPerson", "ExtractedContactPoint"],
         skip=0,
         limit=1,
@@ -81,12 +80,91 @@ def test_fetch_extracted_items_mocked(
         "http://localhost:8080/v0/extracted-item",
         {
             "q": "Tintzmann",
-            "stableTargetId": "NGwfzG8ROsrvIiQIVDVy",
             "entityType": ["ExtractedPerson", "ExtractedContactPoint"],
-            "referenceField": None,
-            "referencedIdentifier": None,
             "skip": "0",
             "limit": "1",
+        },
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "rki/mex",
+        },
+        timeout=10,
+    )
+
+
+def test_fetch_extracted_items_with_reference_filters_mocked(
+    mocked_backend: MagicMock, extracted_person: ExtractedPerson
+) -> None:
+    mocked_return = {"items": [extracted_person.model_dump()], "total": 3}
+    mocked_backend.return_value.json.return_value = mocked_return
+
+    affiliation = str(MergedOrganizationIdentifier.generate(seed=300))
+
+    connector = BackendApiConnector.get()
+    response = connector.fetch_extracted_items(
+        query_string="Tintzmann",
+        entity_type=["ExtractedPerson", "ExtractedContactPoint"],
+        reference_filters=[
+            ReferenceFilter(field="affiliation", identifiers=[affiliation])
+        ],
+        limit=1,
+    )
+
+    assert response.items == [extracted_person]
+    assert response.total == 3
+
+    assert mocked_backend.call_args == call(
+        "POST",
+        "http://localhost:8080/v0/extracted-item/_search",
+        None,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "rki/mex",
+        },
+        timeout=10,
+        data=json.dumps(
+            {
+                "q": "Tintzmann",
+                "entityType": ["ExtractedPerson", "ExtractedContactPoint"],
+                "referenceFilters": [
+                    {"field": "affiliation", "identifiers": [affiliation]}
+                ],
+                "skip": 0,
+                "limit": 1,
+            }
+        ),
+    )
+
+
+def test_fetch_all_extracted_items_mocked(
+    mocked_backend: MagicMock, extracted_person: ExtractedPerson
+) -> None:
+    extracted_person_json = extracted_person.model_dump()
+    mocked_backend.return_value.json.side_effect = [
+        {"status": "ok"},  # status check
+        {"items": [], "total": 103},  # call to gauge the total
+        {"items": [extracted_person_json] * 100, "total": 103},  # first page 0-99
+        {"items": [extracted_person_json] * 3, "total": 103},  # second page 100-103
+    ]
+
+    connector = BackendApiConnector.get()
+    items = list(connector.fetch_all_extracted_items(query_string="Tintzmann"))
+
+    # expect 4 calls: status check, get the total, and get two pages 0-99/100-103
+    assert len(mocked_backend.call_args_list) == 4
+
+    # expect all 103 persons to be there
+    assert items == [extracted_person] * 103
+
+    # expect the last call to be made with the correct parameters
+    assert mocked_backend.call_args == call(
+        "GET",
+        "http://localhost:8080/v0/extracted-item",
+        {
+            "q": "Tintzmann",
+            "entityType": None,
+            "skip": "100",
+            "limit": "100",
         },
         headers={
             "Accept": "application/json",
@@ -142,8 +220,6 @@ def test_fetch_merged_items_mocked(
             "q": "Tintzmann",
             "identifier": None,
             "entityType": ["MergedPerson", "MergedContactPoint"],
-            "referenceField": None,
-            "referencedIdentifier": None,
             "skip": "0",
             "limit": "1",
         },
@@ -152,6 +228,51 @@ def test_fetch_merged_items_mocked(
             "User-Agent": "rki/mex",
         },
         timeout=10,
+    )
+
+
+def test_fetch_merged_items_with_reference_filters_mocked(
+    mocked_backend: MagicMock, merged_person: MergedPerson
+) -> None:
+    mocked_return = {"items": [merged_person.model_dump()], "total": 3}
+    mocked_backend.return_value.json.return_value = mocked_return
+
+    affiliation = str(MergedOrganizationIdentifier.generate(seed=300))
+
+    connector = BackendApiConnector.get()
+    response = connector.fetch_merged_items(
+        query_string="Tintzmann",
+        entity_type=["MergedPerson", "MergedContactPoint"],
+        reference_filters=[
+            ReferenceFilter(field="affiliation", identifiers=[affiliation])
+        ],
+        limit=1,
+    )
+
+    assert response.items == [merged_person]
+    assert response.total == 3
+
+    assert mocked_backend.call_args == call(
+        "POST",
+        "http://localhost:8080/v0/merged-item/_search",
+        None,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "rki/mex",
+        },
+        timeout=10,
+        data=json.dumps(
+            {
+                "q": "Tintzmann",
+                "identifier": None,
+                "entityType": ["MergedPerson", "MergedContactPoint"],
+                "referenceFilters": [
+                    {"field": "affiliation", "identifiers": [affiliation]}
+                ],
+                "skip": 0,
+                "limit": 1,
+            }
+        ),
     )
 
 
@@ -183,8 +304,6 @@ def test_fetch_all_merged_items_mocked(
             "q": "Tintzmann",
             "identifier": None,
             "entityType": None,
-            "referenceField": None,
-            "referencedIdentifier": None,
             "skip": "100",
             "limit": "100",
         },
@@ -241,8 +360,6 @@ def test_fetch_preview_items_mocked(
             "q": "foobar",
             "identifier": None,
             "entityType": None,
-            "referenceField": None,
-            "referencedIdentifier": None,
             "skip": "0",
             "limit": "1",
         },
@@ -277,7 +394,7 @@ def test_get_preview_item_mocked(
     )
 
 
-def test_search_preview_items_mocked(
+def test_fetch_preview_items_with_reference_filters_mocked(
     mocked_backend: MagicMock, preview_person: PreviewPerson
 ) -> None:
     mocked_return = {"items": [preview_person.model_dump()], "total": 3}
@@ -286,10 +403,12 @@ def test_search_preview_items_mocked(
     affiliation = str(MergedOrganizationIdentifier.generate(seed=300))
 
     connector = BackendApiConnector.get()
-    response = connector.search_preview_items(
+    response = connector.fetch_preview_items(
         query_string="Tintzmann",
         entity_type=["PreviewPerson", "PreviewContactPoint"],
-        references=[ReferenceFilter(field="affiliation", identifiers=[affiliation])],
+        reference_filters=[
+            ReferenceFilter(field="affiliation", identifiers=[affiliation])
+        ],
         limit=1,
     )
 
@@ -345,8 +464,6 @@ def test_fetch_publishable_merged_items_mocked(
             "q": "Tintzmann",
             "identifier": None,
             "entityType": ["MergedPerson", "MergedContactPoint"],
-            "referenceField": None,
-            "referencedIdentifier": None,
             "skip": "0",
             "limit": "1",
         },
@@ -355,6 +472,53 @@ def test_fetch_publishable_merged_items_mocked(
             "User-Agent": "rki/mex",
         },
         timeout=10,
+    )
+
+
+def test_fetch_publishable_merged_items_with_reference_filters_mocked(
+    mocked_backend: MagicMock, merged_person: MergedPerson
+) -> None:
+    mocked_return = {"items": [merged_person.model_dump()], "total": 3}
+    mocked_backend.return_value.json.return_value = mocked_return
+
+    affiliation = str(MergedOrganizationIdentifier.generate(seed=300))
+
+    connector = BackendApiConnector.get()
+    response = connector.fetch_publishable_merged_items(
+        publishing_target="invenio",
+        query_string="Tintzmann",
+        entity_type=["MergedPerson", "MergedContactPoint"],
+        reference_filters=[
+            ReferenceFilter(field="affiliation", identifiers=[affiliation])
+        ],
+        limit=1,
+    )
+
+    assert response.items == [merged_person]
+    assert response.total == 3
+
+    assert mocked_backend.call_args == call(
+        "POST",
+        "http://localhost:8080/v0/publishable-merged-item/_search",
+        None,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "rki/mex",
+        },
+        timeout=10,
+        data=json.dumps(
+            {
+                "publishingTarget": "invenio",
+                "q": "Tintzmann",
+                "identifier": None,
+                "entityType": ["MergedPerson", "MergedContactPoint"],
+                "referenceFilters": [
+                    {"field": "affiliation", "identifiers": [affiliation]}
+                ],
+                "skip": 0,
+                "limit": 1,
+            }
+        ),
     )
 
 
@@ -391,8 +555,6 @@ def test_fetch_all_publishable_merged_items_mocked(
             "q": "Tintzmann",
             "identifier": None,
             "entityType": None,
-            "referenceField": None,
-            "referencedIdentifier": None,
             "skip": "100",
             "limit": "100",
         },

--- a/tests/merged/test_main.py
+++ b/tests/merged/test_main.py
@@ -12,12 +12,12 @@ from mex.common.merged.main import (
     _collect_preventive_sources,
     _collect_subtractive_values,
     _create_merged_dict,
-    _ensure_rule_set,
     _ensure_same_entity_type,
     _filter_usable_values,
     _get_merged_class,
     _pick_usable_values,
     create_merged_item,
+    ensure_rule_set,
     is_item_publishable,
     merge_rule_set_responses,
     merge_rules,
@@ -267,7 +267,7 @@ def test_get_merged_class(
 
 
 def test_ensure_rule_set_creates_default() -> None:
-    result = _ensure_rule_set(None, "Person")
+    result = ensure_rule_set(None, "Person")
 
     assert isinstance(result, PersonRuleSetRequest)
 
@@ -275,7 +275,7 @@ def test_ensure_rule_set_creates_default() -> None:
 def test_ensure_rule_set_returns_existing() -> None:
     existing_rule_set = PersonRuleSetRequest()
 
-    result = _ensure_rule_set(existing_rule_set, "Person")
+    result = ensure_rule_set(existing_rule_set, "Person")
 
     assert result is existing_rule_set
 


### PR DESCRIPTION
### PR Context
- backend_api connector was slightly outdated: still using deprecated parameters instead of new reference-filter interface
- it also had a fetch_all for rules and merged, but not for extracted
- drive-by-addition: making ensure_rule_set public for use in mex-backend

### Added

- add `reference_filters` argument to `fetch_*_items` methods of `BackendApiConnector`,
  using POST `_search` endpoints when needed, otherwise sticking with GET
- add `fetch_all_extracted_items` to `BackendApiConnector`, eg for migrations

### Changes

- make `ensure_rule_set` in `mex.common.merged.main` public

### Removed

- BREAKING: remove `search_preview_items` from `BackendApiConnector`,
  use `fetch_preview_items(reference_filters=...)` instead
- BREAKING: drop the deprecated `referenced_identifier`, `reference_field` and
  `stable_target_id` search arguments, use `reference_filters` instead

