### PR TITLE
feature/fix-singleton-store-docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - fixed linting erros caused by ruff update and lock-filemaintenance
+- fix docstrings of `SingletonStore`, `SingleSingletonStore` and `_ConnectorStore`,
+  which incorrectly described the stored singletons as thread-local
 
 ### Security
 

--- a/mex/common/connector/base.py
+++ b/mex/common/connector/base.py
@@ -7,7 +7,7 @@ from mex.common.transform import dromedary_to_snake
 
 
 class _ConnectorStore(SingletonStore["BaseConnector"]):
-    """Thin wrapper for storing thread-local singletons of connectors."""
+    """Thin wrapper for storing one singleton connector instance per class."""
 
     def reset(self) -> None:
         """Close all connectors and remove them from the singleton store."""

--- a/mex/common/context.py
+++ b/mex/common/context.py
@@ -5,7 +5,12 @@ _SingletonT = TypeVar("_SingletonT")
 
 
 class SingletonStore(Generic[_SingletonT]):
-    """Thin wrapper for storing thread-local singletons."""
+    """Thin wrapper for storing one singleton instance per class.
+
+    Instances are kept in a plain dict, so a store is shared by all threads that
+    access it and is not synchronized. Concurrent `load` calls for the same class
+    may each create an instance, of which only the last one is kept.
+    """
 
     def __init__(self) -> None:
         """Create a new singleton store with the given type."""
@@ -35,10 +40,13 @@ class SingletonStore(Generic[_SingletonT]):
 
 
 class SingleSingletonStore(Generic[_SingletonT]):
-    """Thin wrapper for storing a single thread-local singleton.
+    """Thin wrapper for storing a single singleton instance.
 
     Stores only a single instance. Requested class must either be
     the same or a parent class of the stored class.
+
+    Like `SingletonStore`, the instance is shared by all threads that access the
+    store and access to it is not synchronized.
     """
 
     def __init__(self) -> None:


### PR DESCRIPTION
### Fixed

- fix docstrings of `SingletonStore`, `SingleSingletonStore` and `_ConnectorStore`,
  which incorrectly described the stored singletons as thread-local