### PR TITLE
feature/mx-1973-update-api-connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - new template https://github.com/robert-koch-institut/mex-template/releases/tag/1.5.0
 - retry `429` responses with an exponential backoff (about 45s over 5 tries)
 - make `ensure_rule_set` in `mex.common.merged.main` public
+- BREAKING: replace `match_item` on `BackendApiConnector` with `merge_items`
 
 ### Deprecated
 

--- a/mex/common/backend_api/connector.py
+++ b/mex/common/backend_api/connector.py
@@ -28,7 +28,6 @@ from mex.common.models.base.model import BaseModel
 from mex.common.models.person import MergedPerson
 from mex.common.settings import BaseSettings
 from mex.common.types import (
-    AnyExtractedIdentifier,
     AnyMergedIdentifier,
     Identifier,
     MergedPrimarySourceIdentifier,
@@ -547,26 +546,26 @@ class BackendApiConnector(HTTPConnector):
             params={"includeRuleSet": str(include_rule_set).lower()},
         )
 
-    def match_item(
+    def merge_items(
         self,
-        extracted_identifier: AnyExtractedIdentifier,
-        merged_identifier: AnyMergedIdentifier,
+        goner_identifier: AnyMergedIdentifier,
+        keeper_identifier: AnyMergedIdentifier,
     ) -> None:
-        """Match an extracted item to a merged item.
+        """Merge a goner merged item into a keeper merged item.
 
         Args:
-            extracted_identifier: Identifier of the extracted item
-            merged_identifier: Identifier of the merged item
+            goner_identifier: Identifier of the merged item to be merged away
+            keeper_identifier: Identifier of the merged item to keep
 
         Raises:
-            HTTPError: If matching was not accepted
+            HTTPError: If merging was not accepted
         """
         self.request(
             method="POST",
-            endpoint="match",
+            endpoint="merge",
             payload={
-                "extractedIdentifier": str(extracted_identifier),
-                "mergedIdentifier": str(merged_identifier),
+                "gonerIdentifier": str(goner_identifier),
+                "keeperIdentifier": str(keeper_identifier),
             },
         )
 

--- a/tests/backend_api/test_connector.py
+++ b/tests/backend_api/test_connector.py
@@ -19,10 +19,7 @@ from mex.common.models import (
     PreviewPerson,
 )
 from mex.common.testing import Joker
-from mex.common.types import (
-    ExtractedPersonIdentifier,
-    MergedPersonIdentifier,
-)
+from mex.common.types import MergedPersonIdentifier
 from mex.common.types.identifier import MergedOrganizationIdentifier
 
 
@@ -644,16 +641,16 @@ def test_delete_merged_item_mocked(mocked_backend: MagicMock) -> None:
     )
 
 
-def test_match_item_mocked(mocked_backend: MagicMock) -> None:
-    extracted_id = ExtractedPersonIdentifier("e3VhxMhEKyjqN5flzLpiEB")
-    merged_id = MergedPersonIdentifier("NGwfzG8ROsrvIiQIVDVy")
+def test_merge_items_mocked(mocked_backend: MagicMock) -> None:
+    goner_id = MergedPersonIdentifier("e3VhxMhEKyjqN5flzLpiEB")
+    keeper_id = MergedPersonIdentifier("NGwfzG8ROsrvIiQIVDVy")
 
     connector = BackendApiConnector.get()
-    connector.match_item(extracted_id, merged_id)
+    connector.merge_items(goner_id, keeper_id)
 
     assert mocked_backend.call_args == call(
         "POST",
-        "http://localhost:8080/v0/match",
+        "http://localhost:8080/v0/merge",
         None,
         headers={
             "Accept": "application/json",
@@ -663,6 +660,6 @@ def test_match_item_mocked(mocked_backend: MagicMock) -> None:
         data=Joker(),
     )
     assert json.loads(mocked_backend.call_args.kwargs["data"]) == {
-        "extractedIdentifier": "e3VhxMhEKyjqN5flzLpiEB",
-        "mergedIdentifier": "NGwfzG8ROsrvIiQIVDVy",
+        "gonerIdentifier": "e3VhxMhEKyjqN5flzLpiEB",
+        "keeperIdentifier": "NGwfzG8ROsrvIiQIVDVy",
     }


### PR DESCRIPTION
### PR Context

- backend api has changed, update the connector to comply

### Changes

- BREAKING: replace `match_item` on `BackendApiConnector` with `merge_items`